### PR TITLE
chore: add react-router-dom dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react": "^16.7.0",
     "react-app-rewired": "2.0.2-next.0",
     "react-dom": "^16.7.0",
+    "react-router-dom": "^4.3.1",
     "react-scripts": "^2.1.1",
     "react-styleguidist": "^8.0.6",
     "rimraf": "^2.6.2",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -17,7 +17,8 @@
   },
   "devDependencies": {
     "flow-copy-source": "^2.0.2",
-    "microbundle": "^0.8.3"
+    "microbundle": "^0.8.3",
+    "react-router-dom": "^4.3.1"
   },
   "dependencies": {
     "@emotion/core": "^10.0.4",


### PR DESCRIPTION
It is needed for development purposes

<!-- thank you for contributing to Quid UI! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"][committing-and-publishing] guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

This dependency is needed during development, being a peer dependency, it must be explicitly listed under `devDependencies`

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-core

[committing-and-publishing]: https://github.com/quid/ui-framework/blob/master/CONTRIBUTING.md
