### PR TITLE
fix: export ThemeProvider as named export

### DIFF
--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -1,7 +1,7 @@
 This package provides a set of colors, sizes, and font styles, used to style
 the applications created at Quid.
 
-The default export of the package is an Emotion [theme provider][theme-provider]
+The named `ThemeProvider` export of the package is an Emotion [theme provider][theme-provider]
 that should wrap any application to make sure the other Quid components
 are properly styled with the resources provided by this package.
 
@@ -24,7 +24,7 @@ Wrap your component with `ThemeProvider` and, optionally, define the desired
 theme (`light` or `dark`, `light` is default):
 
 ```jsx static
-import ThemeProvider from '@quid/theme';
+import { ThemeProvider } from '@quid/theme';
 
 <ThemeProvider theme="light">
   <Button>I'll use the light theme</Button>
@@ -40,7 +40,7 @@ This can be useful to conditionally style a component depending by its theme.
 
 ```jsx static
 import styled from '@emotion/styled/macro';
-import ThemeProvider from '@quid/theme';
+import { ThemeProvider } from '@quid/theme';
 
 const Test = styled.span`
   color: ${props => props.theme.primary};

--- a/packages/theme/src/index.js
+++ b/packages/theme/src/index.js
@@ -25,4 +25,4 @@ const QuidThemeProvider = ({ theme = 'light', children, ...props }: Props) => (
   <ThemeProvider {...props} theme={themeData[theme]} children={children} />
 );
 
-export default QuidThemeProvider;
+export { QuidThemeProvider as ThemeProvider };

--- a/packages/theme/src/index.test.js
+++ b/packages/theme/src/index.test.js
@@ -9,7 +9,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { ThemeProvider } from 'emotion-theming';
 import * as exps from './index';
-import QuidThemeProvider from './index';
+import { ThemeProvider as QuidThemeProvider } from './index';
 
 it('exports all the expected modules', () => {
   expect(Object.keys(exps)).toMatchInlineSnapshot(`
@@ -18,7 +18,7 @@ Array [
   "sizes",
   "textStyles",
   "withFallback",
-  "default",
+  "ThemeProvider",
   "themes",
 ]
 `);

--- a/src/components/StyleGuide.js
+++ b/src/components/StyleGuide.js
@@ -14,7 +14,7 @@ import Welcome from 'react-styleguidist/lib/rsg-components/Welcome';
 import Error from 'react-styleguidist/lib/rsg-components/Error';
 import NotFound from 'react-styleguidist/lib/rsg-components/NotFound';
 import { DisplayModes } from 'react-styleguidist/lib/consts';
-import ThemeProvider from '@quid/theme';
+import { ThemeProvider } from '@quid/theme';
 
 /**
  * This function will return true, if the sidebar should be visible and false otherwise.

--- a/src/components/Wrapper.js
+++ b/src/components/Wrapper.js
@@ -6,7 +6,7 @@
  */
 // @noflow
 import * as React from 'react';
-import ThemeProvider from '@quid/theme';
+import { ThemeProvider } from '@quid/theme';
 import styled from '@emotion/styled/macro';
 import { CacheProvider } from '@emotion/core';
 import 'what-input';


### PR DESCRIPTION

<!-- thank you for contributing to Quid UI! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"][committing-and-publishing] guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

mixed default and named exports don’t work quite well with microbundle right now

## Affected packages

<!-- List below all the affected packages -->

- @quid/theme

[committing-and-publishing]: https://github.com/quid/refraction/blob/master/CONTRIBUTING.md
