### PR TITLE
fix: use keyframes object notation to avoid Emotion bug

### DIFF
--- a/packages/react-core/src/Text/index.js
+++ b/packages/react-core/src/Text/index.js
@@ -34,22 +34,20 @@ const reduceOpacity = color =>
     .alpha(0.5)
     .string();
 
-const pulse = wf(
-  props => keyframes`
-  0% {
-    background-color: ${props.theme.colors[BACKGROUND[props.theme.current]]};
-  }
-
-  50% {
-    background-color: ${reduceOpacity(
-      props.theme.colors[BACKGROUND[props.theme.current]]
-    )};
-  }
-
-  100% {
-    background-color: ${props.theme.colors[BACKGROUND[props.theme.current]]};
-  }
-`
+const pulse = wf(props =>
+  keyframes({
+    '0%': {
+      backgroundColor: props.theme.colors[BACKGROUND[props.theme.current]],
+    },
+    '50%': {
+      backgroundColor: reduceOpacity(
+        props.theme.colors[BACKGROUND[props.theme.current]]
+      ),
+    },
+    '100%': {
+      backgroundColor: props.theme.colors[BACKGROUND[props.theme.current]],
+    },
+  })
 );
 
 // @component


### PR DESCRIPTION
<!-- thank you for contributing to Quid UI! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"][committing-and-publishing] guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

There are some ongoing issues with Emotion and its `css` and `keyframes` utilities, sometimes an invalid CSS is generated. I'm investigating the root cause of the issue but meanwhile, switching to the object notation fixes the issue.

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-core

[committing-and-publishing]: https://github.com/quid/refraction/blob/master/CONTRIBUTING.md
