### PR TITLE
fix: apply normal style to text by default

### DIFF
--- a/packages/react-core/src/Button/__snapshots__/index.test.js.snap
+++ b/packages/react-core/src/Button/__snapshots__/index.test.js.snap
@@ -13,9 +13,12 @@ exports[`renders a Button with small size 1`] = `
   box-sizing: border-box;
   color: inherit;
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
   font-size: 14px;
   line-height: 1.57;
+  color: #2E3338;
   font-weight: bold;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -93,9 +96,12 @@ exports[`renders a disabled and transparent Button 1`] = `
   box-sizing: border-box;
   color: inherit;
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
   font-size: 14px;
   line-height: 1.57;
+  color: #2E3338;
   font-weight: bold;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -184,9 +190,12 @@ exports[`renders the expected markup 1`] = `
   box-sizing: border-box;
   color: inherit;
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
   font-size: 14px;
   line-height: 1.57;
+  color: #2E3338;
   font-weight: bold;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;

--- a/packages/react-core/src/Text/__snapshots__/index.test.js.snap
+++ b/packages/react-core/src/Text/__snapshots__/index.test.js.snap
@@ -17,6 +17,8 @@ exports[`renders a Skeleton with a different tag 1`] = `
 
 .emotion-0 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
   line-height: 2em;
   color: transparent;
@@ -74,6 +76,8 @@ exports[`renders a Skeleton with set width 1`] = `
 
 .emotion-0 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
   line-height: 2em;
   color: transparent;
@@ -107,6 +111,8 @@ exports[`renders a Skeleton with set width 1`] = `
 exports[`renders a component with a different tag 1`] = `
 .emotion-0 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
   font-size: 20px;
   line-height: 1.4;
@@ -126,6 +132,8 @@ exports[`renders a component with a different tag 1`] = `
 exports[`renders the expected markup 1`] = `
 .emotion-0 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
 }
 
@@ -153,6 +161,8 @@ exports[`renders the plain skeleton 1`] = `
 
 .emotion-0 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
   line-height: 2em;
   color: transparent;

--- a/packages/react-date-picker/src/__snapshots__/Cell.test.js.snap
+++ b/packages/react-date-picker/src/__snapshots__/Cell.test.js.snap
@@ -7,6 +7,8 @@ exports[`renders a disabled cell 1`] = `
   vertical-align: middle;
   color: #2E3338;
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
 }
 
@@ -61,6 +63,8 @@ exports[`renders the expected markup 1`] = `
   vertical-align: middle;
   color: #2E3338;
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
 }
 
@@ -135,6 +139,8 @@ exports[`renders the expected markup 2`] = `
   vertical-align: middle;
   color: #00c1bb;
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
 }
 

--- a/packages/react-date-picker/src/__snapshots__/Row.test.js.snap
+++ b/packages/react-date-picker/src/__snapshots__/Row.test.js.snap
@@ -7,6 +7,8 @@ exports[`renders the expected markup 1`] = `
   vertical-align: middle;
   color: #2E3338;
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
 }
 
@@ -45,6 +47,8 @@ exports[`renders the expected markup 1`] = `
   background-color: #6C7983;
   color: #E3E6E8;
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
   font-weight: bold;
 }

--- a/packages/react-date-picker/src/index.test.js
+++ b/packages/react-date-picker/src/index.test.js
@@ -32,6 +32,8 @@ Array [
   </span>,
   .emotion-0 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
   font-size: 16px;
   line-height: 1.5;

--- a/packages/react-dropdown/src/__snapshots__/index.test.js.snap
+++ b/packages/react-dropdown/src/__snapshots__/index.test.js.snap
@@ -90,6 +90,8 @@ exports[`renders an open dropdown 1`] = `
 
 .emotion-0 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
 }
 
@@ -288,6 +290,8 @@ exports[`renders an open dropdown with categories 1`] = `
 
 .emotion-4 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
 }
 
@@ -335,9 +339,12 @@ exports[`renders an open dropdown with categories 1`] = `
 
 .emotion-0 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
   font-size: 14px;
   line-height: 1.57;
+  color: #2E3338;
   font-weight: bold;
   margin: 0;
   display: -webkit-box;
@@ -718,6 +725,8 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
 
 .emotion-4 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
 }
 
@@ -737,9 +746,12 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
 
 .emotion-0 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
   font-size: 14px;
   line-height: 1.57;
+  color: #2E3338;
   font-weight: bold;
   margin: 0;
   display: -webkit-box;
@@ -1228,6 +1240,8 @@ exports[`using arrow down should hover on element 1`] = `
 
 .emotion-0 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
 }
 
@@ -1389,11 +1403,15 @@ exports[`using useFilter should only return items that match the input value 1`]
 
 .emotion-2 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
 }
 
 .emotion-0 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
   font-weight: bold;
 }

--- a/packages/react-forms/src/InputDate/__snapshots__/index.test.js.snap
+++ b/packages/react-forms/src/InputDate/__snapshots__/index.test.js.snap
@@ -7,9 +7,12 @@ exports[`renders the expected markup 1`] = `
 
 .emotion-7 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
   font-size: 14px;
   line-height: 1.57;
+  color: #2E3338;
   vertical-align: top;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;

--- a/packages/react-forms/src/InputText/__snapshots__/index.test.js.snap
+++ b/packages/react-forms/src/InputText/__snapshots__/index.test.js.snap
@@ -11,9 +11,12 @@ exports[`renders an input with addon 1`] = `
 exports[`renders the expected markup 1`] = `
 .emotion-3 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
   font-size: 14px;
   line-height: 1.57;
+  color: #2E3338;
   vertical-align: top;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;

--- a/packages/theme/src/__snapshots__/textStyles.test.js.snap
+++ b/packages/theme/src/__snapshots__/textStyles.test.js.snap
@@ -3,9 +3,12 @@
 exports[`returns a valid CSS 1`] = `
 .emotion-0 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
   font-size: 14px;
   line-height: 1.57;
+  color: #2E3338;
 }
 
 <T>
@@ -18,12 +21,16 @@ exports[`returns a valid CSS 1`] = `
 exports[`works with "withFallback" powered styles 1`] = `
 .emotion-0 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 1.57;
   color: #2E3338;
   color: #6C7983;
   color: #8F9BA3;
   color: #28beb8;
   cursor: pointer;
   color: rgba(0,193,187,0.6);
+  line-height: 1.57;
+  font-family: IBM Plex Serif,Gudea,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
 }
 
 <T>

--- a/packages/theme/src/textStyles.js
+++ b/packages/theme/src/textStyles.js
@@ -39,10 +39,13 @@ const styles = {
     line-height: 1.57;
     ${secondaryFontFamily}
   `,
-  normal: css`
-    font-size: 14px;
-    line-height: 1.57;
-  `,
+  normal: wf(
+    props => css`
+      font-size: 14px;
+      line-height: 1.57;
+      color: ${props.theme.primary};
+    `
+  ),
   bold: css`
     font-weight: bold;
   `,
@@ -73,12 +76,13 @@ const styles = {
 };
 
 const textStyles = (...ss: Array<string>) => (props: Object) => {
-  const rules = ss.map(s =>
-    typeof styles[s] === 'function' ? styles[s](props) : styles[s]
+  const rules = [styles.normal(props)].concat(
+    ss.map(s =>
+      typeof styles[s] === 'function' ? styles[s](props) : styles[s]
+    )
   );
   return css`
     ${primaryFontFamily};
-    color: ${wf(props => props.theme.primary)(props)};
     ${rules};
   `;
 };

--- a/packages/theme/src/textStyles.test.js
+++ b/packages/theme/src/textStyles.test.js
@@ -22,7 +22,7 @@ it('returns a valid CSS', () => {
 
 it('works with "withFallback" powered styles', () => {
   const T = styled.div`
-    ${textStyles('secondary', 'disabled', 'link', 'highlighted')}
+    ${textStyles('secondary', 'disabled', 'link', 'highlighted', 'body')}
   `;
   expect(mount(<T />)).toMatchSnapshot();
 });


### PR DESCRIPTION
<!-- thank you for contributing to Quid UI! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"][committing-and-publishing] guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

Now the `textStyles` call, by default, will apply the "normal" text style, to avoid to have the consumer remember to add it manually.

## Affected packages

<!-- List below all the affected packages -->

- @quid/theme

[committing-and-publishing]: https://github.com/quid/refraction/blob/master/CONTRIBUTING.md
