### PR TITLE
fix: adds support for multiple refs for mouse outside

### DIFF
--- a/packages/react-forms/src/InputDate/index.js
+++ b/packages/react-forms/src/InputDate/index.js
@@ -39,7 +39,8 @@ type State = {
 
 export default class InputDate extends React.Component<Props, State> {
   component = React.createRef /*:: <HTMLElement> */();
-  s = React.createRef /*:: <HTMLElement> */();
+  refA = React.createRef /*:: <HTMLElement> */();
+  refB = React.createRef /*:: <HTMLElement> */();
 
   state = {
     current: undefined,
@@ -108,8 +109,11 @@ export default class InputDate extends React.Component<Props, State> {
     const isDateValid = !isNaN(dateValue.getTime());
 
     return (
-      <MouseOutside onClickOutside={this.handleClose}>
-        {mouseOutsideRef => (
+      <MouseOutside
+        onClickOutside={this.handleClose}
+        refs={[this.refA, this.refB]}
+      >
+        {() => (
           <Manager>
             <Reference>
               {({ ref }) => (
@@ -130,7 +134,7 @@ export default class InputDate extends React.Component<Props, State> {
                   onClick={this.preventDefault}
                   min={min}
                   max={max}
-                  ref={mergeRefs(ref, mouseOutsideRef)}
+                  ref={mergeRefs(ref, this.refA)}
                   {...props}
                 />
               )}
@@ -145,7 +149,7 @@ export default class InputDate extends React.Component<Props, State> {
                     selected={isDateValid ? dateValue : undefined}
                     minDate={min ? new Date(min) : undefined}
                     maxDate={max ? new Date(max) : undefined}
-                    ref={mergeRefs(ref, this.component)}
+                    ref={mergeRefs(ref, this.component, this.refB)}
                     style={style}
                   />
                 )}

--- a/packages/react-mouse-outside/src/index.md
+++ b/packages/react-mouse-outside/src/index.md
@@ -1,12 +1,14 @@
 ```jsx
 initialState = { txt: 'click outside' };
+const refA = React.createRef();
+
 const callback = () =>
   setState({ txt: 'clicked!' }, () =>
     setTimeout(() => setState({ txt: 'click outside' }), 300)
   );
 
-<MouseOutside onClickOutside={callback}>
-  {getRef => <div ref={getRef}>{state.txt}</div>}
+<MouseOutside onClickOutside={callback} refs={[refA]}>
+  {() => <div ref={refA}>{state.txt}</div>}
 </MouseOutside>;
 ```
 

--- a/packages/react-mouse-outside/src/index.test.js
+++ b/packages/react-mouse-outside/src/index.test.js
@@ -120,3 +120,14 @@ it('should remove event listener on unmount', () => {
   document.dispatchEvent(new Event('mousemove'));
   expect(handleMouseMoveOutside).not.toBeCalled();
 });
+
+it('tests wrong target being provided', () => {
+  const handleMouseMoveOutside = jest.fn();
+  const wrapper = shallow(
+    <MouseOutside onClickOutside={handleMouseMoveOutside}>
+      {ref => <Child ref={ref} />}
+    </MouseOutside>
+  );
+
+  expect(wrapper.instance().areTargetsOutside(null)).toBe(false);
+});


### PR DESCRIPTION
adds support for multiple refs for mouse outside
## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

<!-- Describe what your PR changes -->

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-mouse-outside
- @quid/react-forms

