### PR TITLE
Fix/input group sizing

### DIFF
--- a/packages/react-forms/src/InputColor/__snapshots__/index.test.js.snap
+++ b/packages/react-forms/src/InputColor/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders the expected markup 1`] = `
-.emotion-7 {
+.emotion-9 {
   all: unset;
   display: inline-block;
   border-radius: 2px;
@@ -10,12 +10,25 @@ exports[`renders the expected markup 1`] = `
   border: 1px solid #8F9BA3;
 }
 
-.emotion-7:focus-within {
+.emotion-9:focus-within {
   border-color: #00c1bb;
 }
 
-.emotion-7[data-invalid='true'] {
+.emotion-9[data-invalid='true'] {
   border-color: #E61E27;
+}
+
+.emotion-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-6 input {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .emotion-4 {
@@ -62,72 +75,78 @@ exports[`renders the expected markup 1`] = `
   onChange={[Function]}
 >
   <ForwardRef
-    className="emotion-9 emotion-6"
+    className="emotion-11 emotion-8"
     onChange={[Function]}
   >
     <InputGroup
-      className="emotion-9 emotion-6"
+      className="emotion-11 emotion-8"
     >
       <fieldset
-        className="emotion-6 emotion-7 emotion-8"
+        className="emotion-8 emotion-9 emotion-10"
         data-invalid={false}
         onChange={[Function]}
         onInvalid={[Function]}
       >
-        <input
-          className="emotion-0"
-          key=".0"
-          maxLength={7}
-          onChange={[Function]}
-          value="#000000"
-        />
-        <Wrapper
-          key=".1"
-        >
+        <FlexBox>
           <div
-            className="emotion-4 emotion-5"
+            className="emotion-6 emotion-7"
           >
-            <ColorSelector
-              onBlur={[Function]}
+            <input
+              className="emotion-0"
+              key=".0"
+              maxLength={7}
               onChange={[Function]}
-              onFocus={[Function]}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              type="color"
               value="#000000"
+            />
+            <Wrapper
+              key=".1"
             >
-              <input
-                className="emotion-1 emotion-2"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                type="color"
-                value="#000000"
-              />
-            </ColorSelector>
-            <button
-              className="emotion-3"
-              data-state=""
-              importance="secondary"
-              tabIndex={-1}
-            >
-              <x-icon
-                name="tint"
-                style={
-                  Object {
-                    "color": "#000000",
-                  }
-                }
-              />
-            </button>
+              <div
+                className="emotion-4 emotion-5"
+              >
+                <ColorSelector
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  type="color"
+                  value="#000000"
+                >
+                  <input
+                    className="emotion-1 emotion-2"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    type="color"
+                    value="#000000"
+                  />
+                </ColorSelector>
+                <button
+                  className="emotion-3"
+                  data-state=""
+                  importance="secondary"
+                  tabIndex={-1}
+                >
+                  <x-icon
+                    name="tint"
+                    style={
+                      Object {
+                        "color": "#000000",
+                      }
+                    }
+                  />
+                </button>
+              </div>
+            </Wrapper>
           </div>
-        </Wrapper>
+        </FlexBox>
       </fieldset>
     </InputGroup>
   </ForwardRef>

--- a/packages/react-forms/src/InputDate/index.js
+++ b/packages/react-forms/src/InputDate/index.js
@@ -26,7 +26,6 @@ type Props = {
   onChange: Function,
   isOpen?: boolean,
   onToggle?: Function,
-  className?: string,
   min?: string,
   max?: string,
   disabled?: boolean,
@@ -95,7 +94,6 @@ export default class InputDate extends React.Component<Props, State> {
       onChange, // eslint-disable-line no-unused-vars
       isOpen: isOpenProp, // eslint-disable-line no-unused-vars
       onToggle, // eslint-disable-line no-unused-vars
-      className,
       min,
       max,
       ...props

--- a/packages/react-forms/src/InputFile/__snapshots__/index.test.js.snap
+++ b/packages/react-forms/src/InputFile/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders an InputFile 1`] = `
-.emotion-5 {
+.emotion-7 {
   all: unset;
   display: inline-block;
   border-radius: 2px;
@@ -10,12 +10,25 @@ exports[`renders an InputFile 1`] = `
   border: 1px solid #8F9BA3;
 }
 
-.emotion-5:focus-within {
+.emotion-7:focus-within {
   border-color: #00c1bb;
 }
 
-.emotion-5[data-invalid='true'] {
+.emotion-7[data-invalid='true'] {
   border-color: #E61E27;
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-4 input {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .emotion-1 {
@@ -43,43 +56,49 @@ exports[`renders an InputFile 1`] = `
 
 <InputFile>
   <ForwardRef
-    className="emotion-7 emotion-4"
+    className="emotion-9 emotion-6"
   >
     <InputGroup
-      className="emotion-7 emotion-4"
+      className="emotion-9 emotion-6"
     >
       <fieldset
-        className="emotion-4 emotion-5 emotion-6"
+        className="emotion-6 emotion-7 emotion-8"
         data-invalid={false}
         onChange={[Function]}
         onInvalid={[Function]}
       >
-        <input
-          className="emotion-0"
-          key=".0"
-          onClick={[Function]}
-          readOnly={true}
-          value=""
-        />
-        <FileSelector
-          key=".1"
-          onChange={[Function]}
-          type="file"
-        >
-          <input
-            className="emotion-1 emotion-2"
-            onChange={[Function]}
-            type="file"
-          />
-        </FileSelector>
-        <button
-          className="emotion-3"
-          importance="secondary"
-          key=".2"
-          onClick={[Function]}
-        >
-          Select file
-        </button>
+        <FlexBox>
+          <div
+            className="emotion-4 emotion-5"
+          >
+            <input
+              className="emotion-0"
+              key=".0"
+              onClick={[Function]}
+              readOnly={true}
+              value=""
+            />
+            <FileSelector
+              key=".1"
+              onChange={[Function]}
+              type="file"
+            >
+              <input
+                className="emotion-1 emotion-2"
+                onChange={[Function]}
+                type="file"
+              />
+            </FileSelector>
+            <button
+              className="emotion-3"
+              importance="secondary"
+              key=".2"
+              onClick={[Function]}
+            >
+              Select file
+            </button>
+          </div>
+        </FlexBox>
       </fieldset>
     </InputGroup>
   </ForwardRef>

--- a/packages/react-forms/src/InputGroup/__snapshots__/index.test.js.snap
+++ b/packages/react-forms/src/InputGroup/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`applies the expected class names 1`] = `
-.emotion-3 {
+.emotion-5 {
   all: unset;
   display: inline-block;
   border-radius: 2px;
@@ -10,12 +10,25 @@ exports[`applies the expected class names 1`] = `
   border: 1px solid #8F9BA3;
 }
 
-.emotion-3:focus-within {
+.emotion-5:focus-within {
   border-color: #00c1bb;
 }
 
-.emotion-3[data-invalid='true'] {
+.emotion-5[data-invalid='true'] {
   border-color: #E61E27;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-3 .e1r1kjr12 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .emotion-0 {
@@ -40,23 +53,29 @@ exports[`applies the expected class names 1`] = `
 
 <InputGroup>
   <fieldset
-    className="emotion-3 emotion-4"
+    className="emotion-5 emotion-6"
     data-invalid={false}
     onChange={[Function]}
     onInvalid={[Function]}
   >
-    <span
-      className="emotion-0"
-      key=".$.0"
-    />
-    <span
-      className="emotion-1"
-      key=".$.1"
-    />
-    <span
-      className="emotion-2"
-      key=".$.2"
-    />
+    <FlexBox>
+      <div
+        className="emotion-3 emotion-4"
+      >
+        <span
+          className="emotion-0"
+          key=".$.0"
+        />
+        <span
+          className="emotion-1"
+          key=".$.1"
+        />
+        <span
+          className="emotion-2"
+          key=".$.2"
+        />
+      </div>
+    </FlexBox>
   </fieldset>
 </InputGroup>
 `;

--- a/packages/react-forms/src/InputGroup/index.js
+++ b/packages/react-forms/src/InputGroup/index.js
@@ -10,6 +10,7 @@ import { css } from 'emotion';
 import styled from '@emotion/styled/macro';
 import { withFallback as wf } from '@quid/theme';
 import InvalidHandler from '@quid/react-invalid-handler';
+import InputText from '../InputText';
 
 const toArray = (children): Array<React.Element<any> | Function> =>
   React.Children.toArray(children).length
@@ -17,6 +18,14 @@ const toArray = (children): Array<React.Element<any> | Function> =>
     : Array.isArray(children)
     ? children
     : [];
+
+const FlexBox = styled.div`
+  display: flex;
+
+  ${InputText} {
+    flex: 1;
+  }
+`;
 
 type Props = {
   children: React.Node,
@@ -43,34 +52,36 @@ const InputGroup = styled(
           {...getInputProps({ onChange, onInvalid })}
           {...props}
         >
-          {React.Children.toArray(
-            toArray(children).map((child, i) => {
-              const className =
-                i === 0
-                  ? css`
-                      border-radius: 1px 0 0 1px;
-                      border-left: 0;
-                      border-top: 0;
-                      border-bottom: 0;
-                    `
-                  : i === toArray(children).length - 1
-                  ? css`
-                      border-radius: 0 1px 1px 0;
-                      border-right: 0;
-                      border-top: 0;
-                      border-bottom: 0;
-                    `
-                  : css`
-                      border-radius: 0;
-                      border-top: 0;
-                      border-bottom: 0;
-                    `;
+          <FlexBox>
+            {React.Children.toArray(
+              toArray(children).map((child, i) => {
+                const className =
+                  i === 0
+                    ? css`
+                        border-radius: 1px 0 0 1px;
+                        border-left: 0;
+                        border-top: 0;
+                        border-bottom: 0;
+                      `
+                    : i === toArray(children).length - 1
+                    ? css`
+                        border-radius: 0 1px 1px 0;
+                        border-right: 0;
+                        border-top: 0;
+                        border-bottom: 0;
+                      `
+                    : css`
+                        border-radius: 0;
+                        border-top: 0;
+                        border-bottom: 0;
+                      `;
 
-              return typeof child === 'function'
-                ? child(className)
-                : React.cloneElement(child, { className });
-            })
-          )}
+                return typeof child === 'function'
+                  ? child(className)
+                  : React.cloneElement(child, { className });
+              })
+            )}
+          </FlexBox>
         </fieldset>
       )}
     </InvalidHandler>

--- a/packages/react-forms/src/InputGroup/index.test.js
+++ b/packages/react-forms/src/InputGroup/index.test.js
@@ -12,9 +12,9 @@ import InputGroup from '.';
 it('provides the expected class names', () => {
   mount(
     <InputGroup>
-      {cn => expect(cn).toMatchInlineSnapshot(`"css-1qvwxaf"`)}
-      {cn => expect(cn).toMatchInlineSnapshot(`"css-93venf"`)}
-      {cn => expect(cn).toMatchInlineSnapshot(`"css-1biyg7j"`)}
+      {cn => expect(cn).toMatchInlineSnapshot(`"css-fbg2rn"`)}
+      {cn => expect(cn).toMatchInlineSnapshot(`"css-b3o0lg"`)}
+      {cn => expect(cn).toMatchInlineSnapshot(`"css-18leva3"`)}
     </InputGroup>
   );
 });


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

It makes the InputGroup component work when its width is set to an arbitrary size so that the child input fields will stretch themselves to fit the available space.

Also, fixed a small issue with InputDate that didn't forward `className` properly.

This aims to fix the internal ticket AF-414

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-forms

