### PR TITLE
feat: adds clearSelection support for Dropdown

### DIFF
--- a/packages/react-dropdown/src/MultiDownshift.js
+++ b/packages/react-dropdown/src/MultiDownshift.js
@@ -62,7 +62,7 @@ class MultiDownshift extends React.Component<Props, State> {
   };
 
   handleSelection = (
-    selectedItem: DropdownSelectedItem,
+    selectedItem: DropdownSelectedItem | null,
     downshift: ControllerStateAndHelpers<DropdownSelectedItem>
   ) => {
     const callOnChange = () => {
@@ -73,15 +73,27 @@ class MultiDownshift extends React.Component<Props, State> {
       }
     };
 
-    if (this.props.multiselect) {
-      if (includesId(this.state.selectedItems, selectedItem.id)) {
-        this.removeItem(selectedItem, callOnChange);
-      } else {
-        this.addSelectedItem(selectedItem, callOnChange);
-      }
+    if (selectedItem === null) {
+      this.clearItems(callOnChange);
     } else {
-      this.replaceItem(selectedItem, callOnChange);
+      if (this.props.multiselect) {
+        if (includesId(this.state.selectedItems, selectedItem.id)) {
+          this.removeItem(selectedItem, callOnChange);
+        } else {
+          this.addSelectedItem(selectedItem, callOnChange);
+        }
+      } else {
+        this.replaceItem(selectedItem, callOnChange);
+      }
     }
+  };
+
+  clearItems = (cb?: () => void) => {
+    this.setState(({ selectedItems }) => {
+      return {
+        selectedItems: [],
+      };
+    }, cb);
   };
 
   replaceItem = (item: DropdownSelectedItem, cb?: () => void) => {

--- a/packages/react-dropdown/src/MultiSelect.md
+++ b/packages/react-dropdown/src/MultiSelect.md
@@ -103,7 +103,7 @@ const handleDelete = ({ id }) => {
   items={items}
   categories={categories}
   multiselect={true}
-  selectedItems={selectedItems}
+  initialSelectedItems={selectedItems}
   onChange={mirrorDropdownState}
 >
   {({ getInputProps, removeItem, ...props }) => {

--- a/packages/react-dropdown/src/MultiSelect.md
+++ b/packages/react-dropdown/src/MultiSelect.md
@@ -103,7 +103,7 @@ const handleDelete = ({ id }) => {
   items={items}
   categories={categories}
   multiselect={true}
-  initialSelectedItems={selectedItems}
+  defaultSelectedItems={selectedItems}
   onChange={mirrorDropdownState}
 >
   {({ getInputProps, removeItem, ...props }) => {

--- a/packages/react-dropdown/src/__mocks__/DropdownWrapper.js
+++ b/packages/react-dropdown/src/__mocks__/DropdownWrapper.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Quid, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// @flow
+
+import React from 'react';
+import Dropdown from '../index';
+
+type State = {
+  selectedItems: Array<Object>,
+};
+
+type Props = {
+  items: Array<Object>,
+  skipUpdate?: boolean,
+  initialSelectedItems: Array<Object>,
+};
+
+class DropdownWrapper extends React.Component<Props, State> {
+  state = {
+    selectedItems: this.props.initialSelectedItems,
+  };
+
+  handleChange = (selectedItems: Array<Object>): void => {
+    if (!this.props.skipUpdate) {
+      this.setState({ selectedItems });
+    }
+  };
+
+  render() {
+    return (
+      <Dropdown
+        items={this.props.items}
+        defaultIsOpen={true}
+        selectedItems={this.state.selectedItems}
+        onChange={this.handleChange}
+      >
+        {({ getInputProps }) => <input {...getInputProps()} />}
+      </Dropdown>
+    );
+  }
+}
+
+export default DropdownWrapper;

--- a/packages/react-dropdown/src/__snapshots__/index.test.js.snap
+++ b/packages/react-dropdown/src/__snapshots__/index.test.js.snap
@@ -1304,7 +1304,7 @@ exports[`using arrow down should hover on element 1`] = `
         disabled={false}
         highlight={false}
         value="One"
-        valueToHighlight=""
+        valueToHighlight="Two"
       >
         <span
           className="emotion-0 emotion-1"
@@ -1342,7 +1342,7 @@ exports[`using arrow down should hover on element 1`] = `
         disabled={false}
         highlight={false}
         value="Two"
-        valueToHighlight=""
+        valueToHighlight="Two"
       >
         <span
           className="emotion-0 emotion-1"

--- a/packages/react-dropdown/src/index.js
+++ b/packages/react-dropdown/src/index.js
@@ -33,6 +33,7 @@ const DevFragment =
 type Props = {
   items: Array<DropdownItem>,
   categories?: Array<DropdownCategory>,
+  initialSelectedItems?: Array<DropdownSelectedItem>,
   selectedItems?: Array<DropdownSelectedItem>,
   useFilter?: boolean,
   filterFn?: (
@@ -74,7 +75,8 @@ const Dropdown = ({
   children,
   name = 'dropdown',
   twoColumn = true,
-  selectedItems = [],
+  initialSelectedItems = [],
+  selectedItems,
   initialIsOpen = false,
   placement = 'bottom-start',
   popperModifiers,
@@ -86,9 +88,9 @@ const Dropdown = ({
 }: Props) => (
   <Manager>
     <MultiDownshift
-      initialSelectedItem={selectedItems.length ? selectedItems[0] : null}
       multiselect={multiselect}
       itemToString={item => (item && item.label ? item.label : '')}
+      initialSelectedItems={initialSelectedItems}
       selectedItems={selectedItems}
       initialIsOpen={initialIsOpen}
       onChange={onChange}

--- a/packages/react-dropdown/src/index.js
+++ b/packages/react-dropdown/src/index.js
@@ -33,7 +33,7 @@ const DevFragment =
 type Props = {
   items: Array<DropdownItem>,
   categories?: Array<DropdownCategory>,
-  initialSelectedItems?: Array<DropdownSelectedItem>,
+  defaultSelectedItems?: Array<DropdownSelectedItem>,
   selectedItems?: Array<DropdownSelectedItem>,
   useFilter?: boolean,
   filterFn?: (
@@ -46,7 +46,7 @@ type Props = {
     Object & { getInputProps: Object => GetInputPropsReturn }
   ) => React.Node,
   twoColumn?: boolean,
-  initialIsOpen?: boolean,
+  defaultIsOpen?: boolean,
   highlight?: boolean,
   placement?: Placement,
   popperModifiers?: Modifiers,
@@ -75,9 +75,9 @@ const Dropdown = ({
   children,
   name = 'dropdown',
   twoColumn = true,
-  initialSelectedItems = [],
+  defaultSelectedItems = [],
   selectedItems,
-  initialIsOpen = false,
+  defaultIsOpen = false,
   placement = 'bottom-start',
   popperModifiers,
   popperPositionFixed = false,
@@ -85,87 +85,101 @@ const Dropdown = ({
   onSelect,
   highlight = false,
   ...props
-}: Props) => (
-  <Manager>
-    <MultiDownshift
-      multiselect={multiselect}
-      itemToString={item => (item && item.label ? item.label : '')}
-      initialSelectedItems={initialSelectedItems}
-      selectedItems={selectedItems}
-      initialIsOpen={initialIsOpen}
-      onChange={onChange}
-      onSelect={onSelect}
-    >
-      {(
-        downshift,
-        {
-          openMenu,
-          getItemProps,
-          isOpen,
-          inputValue,
-          highlightedIndex,
-          selectedItems,
-          getInputProps,
-          getRootProps,
-        } = downshift
-      ) => (
-        <DropdownContainer {...getRootProps({ refKey: 'ref', ...props })}>
-          <InputCreator
-            multiselect={multiselect}
-            selectedItems={selectedItems}
-            name={name}
-          />
-          <Popper
-            placement={placement}
-            positionFixed={popperPositionFixed}
-            modifiers={popperModifiers}
-          >
-            {({ ref, style, scheduleUpdate }) => (
-              <DevFragment>
-                <Reference>
-                  {({ ref }) =>
-                    children({
-                      ...downshift,
-                      getInputProps: (inputProps = {}) => {
-                        // NOTE: if you contract this to (inputProps ...) => getInputProps
-                        // this thing is going to break compliation for some reason
-                        return getInputProps({
-                          ...inputProps,
-                          ref,
-                          onFocus: callAll(inputProps.onFocus, openMenu),
-                          onClick: callAll(inputProps.onClick, openMenu),
-                          onChange: callAll(
-                            inputProps.onChange,
-                            scheduleUpdate
-                          ),
-                        });
-                      },
-                    })
-                  }
-                </Reference>
-                {isOpen && (
-                  <DropdownList
-                    ref={ref}
-                    style={style}
-                    twoColumn={twoColumn}
-                    items={items}
-                    categories={categories}
-                    inputValue={inputValue}
-                    getItemProps={getItemProps}
-                    useFilter={useFilter}
-                    filterFn={filterFn}
-                    highlightedIndex={highlightedIndex}
-                    selectedItems={selectedItems}
-                    highlight={highlight}
-                  />
-                )}
-              </DevFragment>
-            )}
-          </Popper>
-        </DropdownContainer>
-      )}
-    </MultiDownshift>
-  </Manager>
-);
+}: Props) => {
+  if (defaultSelectedItems.length && selectedItems != null) {
+    console.error(
+      'Warning: App contains an input of type undefined with both `selectedItems` and `defaultSelectedItems` props. Dropdown elements must be either controlled or uncontrolled (specify either the selectedItems prop, or the defaultSelectedItems prop, but not both). Decide between using a controlled or uncontrolled input element and remove one of these props.'
+    );
+  }
+
+  if (selectedItems != null && onChange == null) {
+    console.error(
+      'Warning: Failed prop type: You provided a `selectedItems` prop to a form field without an `onChange` handler. If the field should be mutable use `defaultSelectedItems`. Otherwise, set `onChange`.'
+    );
+  }
+  return (
+    <Manager>
+      <MultiDownshift
+        multiselect={multiselect}
+        itemToString={item => (item && item.label ? item.label : '')}
+        defaultSelectedItems={defaultSelectedItems}
+        selectedItems={selectedItems}
+        defaultIsOpen={defaultIsOpen}
+        onChange={onChange}
+        onSelect={onSelect}
+        useFilter={useFilter}
+      >
+        {(
+          downshift,
+          {
+            openMenu,
+            getItemProps,
+            isOpen,
+            inputValue,
+            highlightedIndex,
+            selectedItems,
+            getInputProps,
+            getRootProps,
+          } = downshift
+        ) => (
+          <DropdownContainer {...getRootProps({ refKey: 'ref', ...props })}>
+            <InputCreator
+              multiselect={multiselect}
+              selectedItems={selectedItems}
+              name={name}
+            />
+            <Popper
+              placement={placement}
+              positionFixed={popperPositionFixed}
+              modifiers={popperModifiers}
+            >
+              {({ ref, style, scheduleUpdate }) => (
+                <DevFragment>
+                  <Reference>
+                    {({ ref }) =>
+                      children({
+                        ...downshift,
+                        getInputProps: (inputProps = {}) => {
+                          // NOTE: if you contract this to (inputProps ...) => getInputProps
+                          // this thing is going to break compliation for some reason
+                          return getInputProps({
+                            ...inputProps,
+                            ref,
+                            onFocus: callAll(inputProps.onFocus, openMenu),
+                            onClick: callAll(inputProps.onClick, openMenu),
+                            onChange: callAll(
+                              inputProps.onChange,
+                              scheduleUpdate
+                            ),
+                          });
+                        },
+                      })
+                    }
+                  </Reference>
+                  {isOpen && (
+                    <DropdownList
+                      ref={ref}
+                      style={style}
+                      twoColumn={twoColumn}
+                      items={items}
+                      categories={categories}
+                      inputValue={inputValue}
+                      getItemProps={getItemProps}
+                      useFilter={useFilter}
+                      filterFn={filterFn}
+                      highlightedIndex={highlightedIndex}
+                      selectedItems={selectedItems}
+                      highlight={highlight}
+                    />
+                  )}
+                </DevFragment>
+              )}
+            </Popper>
+          </DropdownContainer>
+        )}
+      </MultiDownshift>
+    </Manager>
+  );
+};
 
 export default Dropdown;

--- a/packages/react-dropdown/src/index.md
+++ b/packages/react-dropdown/src/index.md
@@ -20,7 +20,43 @@ const items = [
   { id: 131, label: 'One' },
 ];
 
-<Dropdown items={items} selectedItems={[items[0]]}>
+<Dropdown items={items} initialSelectedItems={[items[3]]}>
+  {({ getInputProps }) => <InputText readOnly {...getInputProps()} />}
+</Dropdown>;
+```
+
+This is usecase will allow you to use `Dropdown` as a controlled component.
+
+```js
+initialState = {
+  selectedItems: [{ id: 10, label: 'One' }],
+};
+
+const items = [
+  { id: 10, label: 'One' },
+  { id: 22, label: 'Two' },
+  { id: 33, label: 'Three' },
+  { id: 44, label: 'Four' },
+  { id: 55, label: 'Four' },
+  { id: 66, label: 'Three' },
+  { id: 77, label: 'Four' },
+  { id: 88, label: 'Three' },
+  { id: 99, label: 'Four' },
+  { id: 101, label: 'Three' },
+  { id: 111, label: 'Four' },
+  { id: 121, label: 'Three' },
+  { id: 131, label: 'One' },
+];
+
+<Dropdown
+  items={items}
+  selectedItems={state.selectedItems}
+  onChange={newSelectedItems => {
+    setState({
+      selectedItems: newSelectedItems,
+    });
+  }}
+>
   {({ getInputProps }) => <InputText readOnly {...getInputProps()} />}
 </Dropdown>;
 ```
@@ -56,7 +92,7 @@ const categories = [
   items={items}
   categories={categories}
   twoColumn={false}
-  selectedItems={[items[2]]}
+  initialSelectedItems={[items[2]]}
 >
   {({ getInputProps }) => <InputText readOnly {...getInputProps()} />}
 </Dropdown>;

--- a/packages/react-dropdown/src/index.md
+++ b/packages/react-dropdown/src/index.md
@@ -20,7 +20,7 @@ const items = [
   { id: 131, label: 'One' },
 ];
 
-<Dropdown items={items} initialSelectedItems={[items[3]]}>
+<Dropdown items={items} defaultSelectedItems={[items[3]]}>
   {({ getInputProps }) => <InputText readOnly {...getInputProps()} />}
 </Dropdown>;
 ```
@@ -50,14 +50,14 @@ const items = [
 
 <Dropdown
   items={items}
-  selectedItems={state.selectedItems}
+  selectedItems={[]}
   onChange={newSelectedItems => {
     setState({
       selectedItems: newSelectedItems,
     });
   }}
 >
-  {({ getInputProps }) => <InputText readOnly {...getInputProps()} />}
+  {({ getInputProps }) => <InputText {...getInputProps()} />}
 </Dropdown>;
 ```
 
@@ -92,7 +92,7 @@ const categories = [
   items={items}
   categories={categories}
   twoColumn={false}
-  initialSelectedItems={[items[2]]}
+  defaultSelectedItems={[items[2]]}
 >
   {({ getInputProps }) => <InputText readOnly {...getInputProps()} />}
 </Dropdown>;

--- a/packages/react-dropdown/src/index.test.js
+++ b/packages/react-dropdown/src/index.test.js
@@ -546,3 +546,34 @@ it('Children provided trough items should be present', () => {
   expect(children.prop('data-itemid')).toBe(131);
   expect(children.length).toBe(1);
 });
+
+it('should clear the previous selected items', () => {
+  const wrapper = mount(
+    <Dropdown items={[{ id: 10, label: 'Hello world' }]} initialIsOpen={true}>
+      {({ getInputProps, clearSelection }) => (
+        <div>
+          <Input {...getInputProps()} />
+          <button onClick={clearSelection}>Reset</button>
+        </div>
+      )}
+    </Dropdown>
+  );
+
+  wrapper.find('ul li').simulate('click');
+
+  expect(
+    wrapper
+      .find('input')
+      .at(0)
+      .props().value
+  ).toBe(10);
+
+  wrapper.find('button').simulate('click');
+
+  expect(
+    wrapper
+      .find('input')
+      .at(0)
+      .props().value
+  ).toBe('');
+});

--- a/packages/react-dropdown/src/index.test.js
+++ b/packages/react-dropdown/src/index.test.js
@@ -559,7 +559,10 @@ it('should clear the previous selected items', () => {
     </Dropdown>
   );
 
-  wrapper.find('ul li').simulate('click');
+  wrapper
+    .find('ul li')
+    .at(0)
+    .simulate('click');
 
   expect(
     wrapper
@@ -576,4 +579,30 @@ it('should clear the previous selected items', () => {
       .at(0)
       .props().value
   ).toBe('');
+});
+
+it('onChange should be called with the newly selected items', () => {
+  const onChangeFn = jest.fn();
+
+  const wrapper = mount(
+    <Dropdown
+      items={items}
+      initialIsOpen={true}
+      selectedItems={[items[0]]}
+      onChange={onChangeFn}
+    >
+      {({ getInputProps }) => <Input {...getInputProps()} />}
+    </Dropdown>
+  );
+
+  wrapper
+    .find('ul li')
+    .hostNodes()
+    .at(1)
+    .simulate('click');
+
+  expect(onChangeFn).toHaveBeenCalledWith(
+    [{ id: 22, label: 'Two' }],
+    expect.anything()
+  );
 });

--- a/packages/react-dropdown/src/index.test.js
+++ b/packages/react-dropdown/src/index.test.js
@@ -8,6 +8,7 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { mount } from 'enzyme';
+import DropdownWrapper from './__mocks__/DropdownWrapper';
 import Dropdown from './index';
 import DropdownList, { List } from './List';
 import { Item, HIGHLIGHTED, SELECTED } from './Items';
@@ -57,8 +58,8 @@ const categories = [
 it('renders items without crashing', () => {
   const div = document.createElement('div');
   ReactDOM.render(
-    <Dropdown items={items.slice(0, 2)} initialIsOpen={true}>
-      {({ getInputProps }) => <Input {...getInputProps()} />}
+    <Dropdown items={items.slice(0, 2)} defaultIsOpen={true}>
+      {({ getInputProps }) => <input {...getInputProps()} />}
     </Dropdown>,
     div
   );
@@ -67,7 +68,7 @@ it('renders items without crashing', () => {
 it('renders a basic closed dropdown', () => {
   const wrapper = mount(
     <Dropdown items={items.slice(0, 2)}>
-      {({ getInputProps }) => <Input {...getInputProps()} />}
+      {({ getInputProps }) => <input {...getInputProps()} />}
     </Dropdown>
   );
   expect(wrapper).toMatchSnapshot();
@@ -75,8 +76,8 @@ it('renders a basic closed dropdown', () => {
 
 it('renders an open dropdown', () => {
   const wrapper = mount(
-    <Dropdown items={items.slice(0, 2)} initialIsOpen={true}>
-      {({ getInputProps }) => <Input {...getInputProps()} />}
+    <Dropdown items={items.slice(0, 2)} defaultIsOpen={true}>
+      {({ getInputProps }) => <input {...getInputProps()} />}
     </Dropdown>
   );
   expect(wrapper).toMatchSnapshot();
@@ -87,10 +88,10 @@ it('renders an open dropdown with categories', () => {
     <Dropdown
       items={items.slice(0, 4)}
       categories={categories.slice(0, 2)}
-      initialIsOpen={true}
+      defaultIsOpen={true}
       twoColumn={false}
     >
-      {({ getInputProps }) => <Input {...getInputProps()} />}
+      {({ getInputProps }) => <input {...getInputProps()} />}
     </Dropdown>
   );
   expect(wrapper.find('DropdownContainer')).toMatchSnapshot();
@@ -101,10 +102,10 @@ it('renders an open dropdown with categories and twoColumn', () => {
     <Dropdown
       items={items.slice(0, 4)}
       categories={categories.slice(0, 2)}
-      initialIsOpen={true}
+      defaultIsOpen={true}
       twoColumn={true}
     >
-      {({ getInputProps }) => <Input {...getInputProps()} />}
+      {({ getInputProps }) => <input {...getInputProps()} />}
     </Dropdown>
   );
   expect(wrapper).toMatchSnapshot();
@@ -116,11 +117,11 @@ it('onChanges gets called when selecting second value', () => {
     <Dropdown
       items={items}
       categories={categories}
-      initialIsOpen={true}
+      defaultIsOpen={true}
       twoColumn={true}
       onChange={handleChange}
     >
-      {({ getInputProps }) => <Input {...getInputProps()} />}
+      {({ getInputProps }) => <input {...getInputProps()} />}
     </Dropdown>
   );
 
@@ -142,7 +143,7 @@ it('onChanges gets called when selecting first value', () => {
     <Dropdown
       items={items}
       categories={categories}
-      initialIsOpen={true}
+      defaultIsOpen={true}
       twoColumn={true}
       onChange={handleChange}
     >
@@ -182,11 +183,11 @@ it('multiselect should be visible in the onChange callback', () => {
   const wrapper = mount(
     <Dropdown
       items={items}
-      initialIsOpen={true}
+      defaultIsOpen={true}
       multiselect={true}
       onChange={handleChange}
     >
-      {({ getInputProps }) => <Input {...getInputProps()} />}
+      {({ getInputProps }) => <input {...getInputProps()} />}
     </Dropdown>
   );
   //Clicks on the first element
@@ -296,7 +297,7 @@ it('using arrow down and return key should select another element', () => {
   const wrapper = mount(
     <Dropdown
       items={items}
-      initialIsOpen={true}
+      defaultIsOpen={true}
       onSelect={handleSelect}
       multiselect={true}
     >
@@ -316,7 +317,7 @@ it('using useFilter should only return items that match the input value', () => 
   const wrapper = mount(
     <Dropdown
       items={items}
-      initialIsOpen={true}
+      defaultIsOpen={true}
       useFilter={true}
       highlight={true}
     >
@@ -332,7 +333,7 @@ it('using useFilter should only return items that match the input value', () => 
 
 it('DropDown list should return null when filtering returns 0 items', () => {
   const wrapper = mount(
-    <Dropdown items={items} initialIsOpen={true} useFilter={true}>
+    <Dropdown items={items} defaultIsOpen={true} useFilter={true}>
       {({ getInputProps }) => <Input {...getInputProps()} />}
     </Dropdown>
   );
@@ -348,11 +349,11 @@ it('Two clicks on the same item should call onChange twice, at the end nothing s
   const wrapper = mount(
     <Dropdown
       items={items}
-      initialIsOpen={true}
+      defaultIsOpen={true}
       onChange={handleChange}
       multiselect={true}
     >
-      {({ getInputProps }) => <Input {...getInputProps()} />}
+      {({ getInputProps }) => <input {...getInputProps()} />}
     </Dropdown>
   );
 
@@ -376,8 +377,8 @@ it('Two clicks on the same item should call onChange twice, at the end nothing s
 
 it('hovering on an item makes it highlighted', () => {
   const wrapper = mount(
-    <Dropdown items={items} initialIsOpen={true} categories={categories}>
-      {({ getInputProps }) => <Input {...getInputProps()} />}
+    <Dropdown items={items} defaultIsOpen={true} categories={categories}>
+      {({ getInputProps }) => <input {...getInputProps()} />}
     </Dropdown>
   );
 
@@ -398,8 +399,8 @@ it('Should not fail when a certaing category doesnt have any item.', () => {
   const extraCategory = [...categories, { id: 'x', label: 'Category X' }];
   expect(() =>
     mount(
-      <Dropdown items={items} initialIsOpen={true} categories={extraCategory}>
-        {({ getInputProps }) => <Input {...getInputProps()} />}
+      <Dropdown items={items} defaultIsOpen={true} categories={extraCategory}>
+        {({ getInputProps }) => <input {...getInputProps()} />}
       </Dropdown>
     )
   ).not.toThrowError();
@@ -411,10 +412,10 @@ it('Empty item label should not break anything.', () => {
     <Dropdown
       items={[{ id: 10, label: '' }]}
       multiselect={true}
-      initialIsOpen={true}
+      defaultIsOpen={true}
       onSelect={handleSelect}
     >
-      {({ getInputProps }) => <Input {...getInputProps()} />}
+      {({ getInputProps }) => <input {...getInputProps()} />}
     </Dropdown>
   );
 
@@ -435,8 +436,9 @@ it('initial selected item should set the input value', () => {
     <Dropdown
       items={items}
       categories={categories}
-      initialIsOpen={true}
+      defaultIsOpen={true}
       selectedItems={selectedItems}
+      onChange={() => {}}
     >
       {({ getInputProps }) => <Input {...getInputProps()} />}
     </Dropdown>
@@ -452,8 +454,9 @@ it('using arrow down should hover on element', () => {
       items={items}
       categories={categories.reverse()}
       twoColumn={false}
-      initialIsOpen={true}
+      defaultIsOpen={true}
       selectedItems={selectedItems}
+      onChange={() => {}}
       multiselect={true}
     >
       {({ getInputProps }) => <Input {...getInputProps()} />}
@@ -522,7 +525,7 @@ it('supports dark theme', () => {
   ).toHaveStyleRule('background-color', 'gray6');
 });
 
-it('Children provided trough items should be present', () => {
+it('Children provided trough itemds should be present', () => {
   const wrapper = mount(
     <Dropdown
       items={[
@@ -537,9 +540,9 @@ it('Children provided trough items should be present', () => {
           ),
         },
       ]}
-      initialIsOpen={true}
+      defaultIsOpen={true}
     >
-      {({ getInputProps }) => <Input {...getInputProps()} />}
+      {({ getInputProps }) => <input {...getInputProps()} />}
     </Dropdown>
   );
   const children = wrapper.find('div[data-child="hw"]');
@@ -547,12 +550,12 @@ it('Children provided trough items should be present', () => {
   expect(children.length).toBe(1);
 });
 
-it('should clear the previous selected items', () => {
+it('should clear the previously selected items', () => {
   const wrapper = mount(
-    <Dropdown items={[{ id: 10, label: 'Hello world' }]} initialIsOpen={true}>
+    <Dropdown items={[{ id: 10, label: 'Hello world' }]} defaultIsOpen={true}>
       {({ getInputProps, clearSelection }) => (
         <div>
-          <Input {...getInputProps()} />
+          <input {...getInputProps()} />
           <button onClick={clearSelection}>Reset</button>
         </div>
       )}
@@ -587,11 +590,11 @@ it('onChange should be called with the newly selected items', () => {
   const wrapper = mount(
     <Dropdown
       items={items}
-      initialIsOpen={true}
+      defaultIsOpen={true}
       selectedItems={[items[0]]}
       onChange={onChangeFn}
     >
-      {({ getInputProps }) => <Input {...getInputProps()} />}
+      {({ getInputProps }) => <input {...getInputProps()} />}
     </Dropdown>
   );
 
@@ -605,4 +608,140 @@ it('onChange should be called with the newly selected items', () => {
     [{ id: 22, label: 'Two' }],
     expect.anything()
   );
+});
+
+it('changing value using controlled component should result in the good value', () => {
+  const wrapper = mount(
+    <DropdownWrapper initialSelectedItems={[items[1]]} items={items} />
+  );
+  wrapper
+    .find('ul li')
+    .hostNodes()
+    .at(1)
+    .simulate('click');
+
+  expect(
+    wrapper
+      .find('input')
+      .at(0)
+      .props().value
+  ).toBe(22);
+
+  expect(
+    wrapper
+      .find('input')
+      .at(1)
+      .props().value
+  ).toBe('Two');
+});
+
+it('changing value and not updating it on change on controlled component should not override the input values', () => {
+  const wrapper = mount(
+    <DropdownWrapper
+      initialSelectedItems={[items[2]]}
+      items={items}
+      skipUpdate={true}
+    />
+  );
+  wrapper
+    .find('ul li')
+    .hostNodes()
+    .at(5)
+    .simulate('click');
+
+  expect(
+    wrapper
+      .find('input')
+      .at(0)
+      .props().value
+  ).toBe(33);
+
+  expect(
+    wrapper
+      .find('input')
+      .at(1)
+      .props().value
+  ).toBe('Three');
+});
+
+it('console error called when both defaultSelectedItems and selectedItems are provided', () => {
+  const spy = jest.spyOn(console, 'error');
+
+  mount(
+    <Dropdown
+      items={items}
+      defaultSelectedItems={[items[0]]}
+      selectedItems={[items[0]]}
+      onChange={() => {}}
+    >
+      {({ getInputProps }) => <input {...getInputProps()} />}
+    </Dropdown>
+  );
+
+  mount(
+    <Dropdown
+      items={items}
+      defaultSelectedItems={[items[0]]}
+      selectedItems={[items[0]]}
+    >
+      {({ getInputProps }) => <input {...getInputProps()} />}
+    </Dropdown>
+  );
+
+  expect(spy).toHaveBeenCalledWith(
+    'Warning: App contains an input of type undefined with both `selectedItems` and `defaultSelectedItems` props. Dropdown elements must be either controlled or uncontrolled (specify either the selectedItems prop, or the defaultSelectedItems prop, but not both). Decide between using a controlled or uncontrolled input element and remove one of these props.'
+  );
+
+  expect(spy).toHaveBeenCalledWith(
+    'Warning: Failed prop type: You provided a `selectedItems` prop to a form field without an `onChange` handler. If the field should be mutable use `defaultSelectedItems`. Otherwise, set `onChange`.'
+  );
+});
+
+it('tests functionality of defaultSelectedItems are properly set', () => {
+  const wrapper = mount(
+    <Dropdown
+      items={items}
+      defaultSelectedItems={[items[5]]}
+      defaultIsOpen={true}
+      onChange={() => {}}
+    >
+      {({ getInputProps }) => <input {...getInputProps()} />}
+    </Dropdown>
+  );
+
+  expect(
+    wrapper
+      .find('input')
+      .at(0)
+      .props().value
+  ).toBe(66);
+
+  expect(
+    wrapper
+      .find('input')
+      .at(1)
+      .props().value
+  ).toBe('Six');
+});
+
+it('empty selected items should result in empty string input value ', () => {
+  const wrapper = mount(
+    <DropdownWrapper
+      initialSelectedItems={[]}
+      items={[{ id: 11, label: 'asd' }]}
+    />
+  );
+
+  wrapper
+    .find('ul li')
+    .hostNodes()
+    .at(0)
+    .simulate('click');
+
+  expect(
+    wrapper
+      .find('input')
+      .at(0)
+      .props().value
+  ).toBe(11);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -12061,7 +12061,7 @@ react-resize-aware@^2.7.2:
   resolved "https://registry.npmjs.org/react-resize-aware/-/react-resize-aware-2.7.2.tgz#38a0040daaa28dfa9b88994889fbb1e2aa66df83"
   integrity sha512-XyweQ3YTiZzNG1T5PNpCXvnpsI7mdy4A2oeySFToh8v02Yf+kOiUyWprvyp6T68fFB848w2F3RKfzH7KDk75JQ==
 
-react-router-dom@^4.3.1:
+react-router-dom@^4.0.0, react-router-dom@^4.3.1:
   version "4.3.1"
   resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz#4c2619fc24c4fa87c9fd18f4fb4a43fe63fbd5c6"
   integrity sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description
Makes `clearSelection` work for dropdown. It is needed for further development of AF-473.
Adds support for being used as a controlled component. See example in the `index.md`.
Here is how to test clearSelection:

```js
const items = [
  { id: 10, label: 'One' },
  { id: 22, label: 'Two' },
  { id: 33, label: 'Three' },
  { id: 44, label: 'Four' },
  { id: 55, label: 'Four' },
  { id: 66, label: 'Three' },
  { id: 77, label: 'Four' },
  { id: 88, label: 'Three' },
  { id: 99, label: 'Four' },
  { id: 101, label: 'Three' },
  { id: 111, label: 'Four' },
  { id: 121, label: 'Three' },
  { id: 131, label: 'One' },
];

<Dropdown items={items} >
  {({ getInputProps, clearSelection }) => <div><InputText readOnly {...getInputProps()} /><button onClick={clearSelection}>Clear selection</button></div>}
</Dropdown>;
```

## Affected packages
- @quid/react-dropdown



