### PR TITLE
refactor: simplify MultiDownshift code

### DIFF
--- a/packages/react-dropdown/src/MultiDownshift.js
+++ b/packages/react-dropdown/src/MultiDownshift.js
@@ -41,14 +41,10 @@ type State = {
 };
 
 class MultiDownshift extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-
-    this.state = {
-      selectedItems: this.props.defaultSelectedItems,
-      inputValue: this.getDefaultInputValue() || '',
-    };
-  }
+  state = {
+    selectedItems: this.props.defaultSelectedItems,
+    inputValue: this.getDefaultInputValue(),
+  };
 
   getDefaultInputValue(): string {
     if (
@@ -101,9 +97,7 @@ class MultiDownshift extends React.Component<Props, State> {
 
     const selectedItems = this.getSelectedItems();
     let newSelectedItems = [];
-    if (selectedItem === null) {
-      newSelectedItems = this.clearItems();
-    } else {
+    if (selectedItem != null) {
       if (this.props.multiselect) {
         if (includesId(selectedItems, selectedItem.id)) {
           newSelectedItems = this.removeItem(selectedItem, selectedItems);
@@ -114,16 +108,15 @@ class MultiDownshift extends React.Component<Props, State> {
         newSelectedItems = this.replaceItem(selectedItem);
       }
     }
+
     if (this.isSelectedItemsPresentInProps()) {
       //Updating the inputValue is necessary when Dropdown is used as controlled component and useFilter is true
       this.setState(
-        ({ inputValue }) => {
-          return {
-            inputValue: selectedItems.length
-              ? selectedItems[selectedItems.length - 1].label
-              : inputValue,
-          };
-        },
+        ({ inputValue }) => ({
+          inputValue: selectedItems.length
+            ? selectedItems[selectedItems.length - 1].label
+            : inputValue,
+        }),
         () => {
           callOnChange(newSelectedItems);
         }
@@ -140,50 +133,32 @@ class MultiDownshift extends React.Component<Props, State> {
     }
   };
 
-  isSelectedItemsPresentInProps() {
-    return this.props.selectedItems ? true : false;
-  }
+  isSelectedItemsPresentInProps = () => this.props.selectedItems != null;
 
-  getSelectedItems() {
-    if (this.props.selectedItems) {
-      return this.props.selectedItems;
-    }
-    return this.state.selectedItems;
-  }
+  getSelectedItems = () => this.props.selectedItems || this.state.selectedItems;
 
-  clearItems = () => {
-    return [];
-  };
-
-  replaceItem = (item: DropdownSelectedItem) => {
-    return [item];
-  };
+  replaceItem = (item: DropdownSelectedItem): Array<DropdownSelectedItem> => [
+    item,
+  ];
 
   removeItem = (
     item: DropdownSelectedItem,
     selectedItems: Array<DropdownSelectedItem>
-  ): Array<DropdownSelectedItem> => {
-    return selectedItems.filter(({ id }) => id !== item.id);
-  };
+  ): Array<DropdownSelectedItem> =>
+    selectedItems.filter(({ id }) => id !== item.id);
 
   addSelectedItem = (
     item: DropdownSelectedItem,
     selectedItems: Array<DropdownSelectedItem>
-  ) => {
-    return [...selectedItems, item];
-  };
+  ): Array<DropdownSelectedItem> => [...selectedItems, item];
 
   getStateAndHelpers = (
     downshift: ControllerStateAndHelpers<DropdownSelectedItem>
-  ): MultiControllerStateAndHelpers => {
-    const { removeItem } = this;
-
-    return {
-      removeItem,
-      selectedItems: this.getSelectedItems(),
-      ...downshift,
-    };
-  };
+  ): MultiControllerStateAndHelpers => ({
+    removeItem: this.removeItem,
+    selectedItems: this.getSelectedItems(),
+    ...downshift,
+  });
 
   handleInputValueChange = (inputValue: string): void => {
     this.setState({

--- a/packages/react-dropdown/src/index.js
+++ b/packages/react-dropdown/src/index.js
@@ -75,7 +75,7 @@ const Dropdown = ({
   children,
   name = 'dropdown',
   twoColumn = true,
-  defaultSelectedItems = [],
+  defaultSelectedItems,
   selectedItems,
   defaultIsOpen = false,
   placement = 'bottom-start',
@@ -102,7 +102,7 @@ const Dropdown = ({
       <MultiDownshift
         multiselect={multiselect}
         itemToString={item => (item && item.label ? item.label : '')}
-        defaultSelectedItems={defaultSelectedItems}
+        defaultSelectedItems={defaultSelectedItems || []}
         selectedItems={selectedItems}
         defaultIsOpen={defaultIsOpen}
         onChange={onChange}

--- a/packages/react-dropdown/src/index.js
+++ b/packages/react-dropdown/src/index.js
@@ -86,7 +86,7 @@ const Dropdown = ({
   highlight = false,
   ...props
 }: Props) => {
-  if (defaultSelectedItems.length && selectedItems != null) {
+  if (defaultSelectedItems != null && selectedItems != null) {
     console.error(
       'Warning: App contains an input of type undefined with both `selectedItems` and `defaultSelectedItems` props. Dropdown elements must be either controlled or uncontrolled (specify either the selectedItems prop, or the defaultSelectedItems prop, but not both). Decide between using a controlled or uncontrolled input element and remove one of these props.'
     );

--- a/packages/react-dropdown/src/index.test.js
+++ b/packages/react-dropdown/src/index.test.js
@@ -665,6 +665,8 @@ it('changing value and not updating it on change on controlled component should 
 });
 
 it('console error called when both defaultSelectedItems and selectedItems are provided', () => {
+  // $FlowIgnoreMe(fzivolo): we don't want to pollute the Jest output
+  console.error = jest.fn();
   const spy = jest.spyOn(console, 'error');
 
   mount(


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

Simplifies the code removing `constructor`, un-needed explicit returns, making some types slightly clearer, and converting normal function methods into auto-bound arrow functions to make sure `this` is always the expected one

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-dropdown

