### PR TITLE
test: switch between uncontrolled and controlled

### DIFF
--- a/packages/react-dropdown/src/index.test.js
+++ b/packages/react-dropdown/src/index.test.js
@@ -745,3 +745,90 @@ it('empty selected items should result in empty string input value ', () => {
       .props().value
   ).toBe(11);
 });
+
+it('properly switches from fully uncontrolled to fully controlled', () => {
+  const wrapper = mount(
+    <Dropdown
+      items={items}
+      defaultSelectedItems={[items[5]]}
+      defaultIsOpen={true}
+      onChange={() => {}}
+    >
+      {({ getInputProps }) => <input {...getInputProps()} />}
+    </Dropdown>
+  );
+
+  expect(
+    wrapper
+      .find('input')
+      .at(0)
+      .props().value
+  ).toBe(66);
+
+  wrapper.setProps({ defaultSelectedItems: null, selectedItems: [items[6]] });
+
+  expect(
+    wrapper
+      .find('input')
+      .at(0)
+      .props().value
+  ).toBe(77);
+});
+
+it('updates state of fully uncontrolled component', () => {
+  const wrapper = mount(
+    <Dropdown
+      items={items}
+      defaultSelectedItems={[items[5]]}
+      defaultIsOpen={true}
+      onChange={() => {}}
+    >
+      {({ getInputProps }) => <input {...getInputProps()} />}
+    </Dropdown>
+  );
+
+  expect(
+    wrapper
+      .find('input')
+      .at(0)
+      .props().value
+  ).toBe(66);
+
+  wrapper.setProps({ defaultSelectedItems: [items[6]] });
+
+  expect(
+    wrapper
+      .find('input')
+      .at(0)
+      .props().value
+  ).toBe(77);
+});
+
+it('properly switches from fully controlled to fully uncontrolled', () => {
+  const wrapper = mount(
+    <Dropdown
+      items={items}
+      selectedItems={[items[5]]}
+      defaultIsOpen={true}
+      onChange={() => {}}
+    >
+      {({ getInputProps }) => <input {...getInputProps()} />}
+    </Dropdown>
+  );
+
+  expect(
+    wrapper
+      .find('input')
+      .at(0)
+      .props().value
+  ).toBe(66);
+
+  wrapper.setProps({ selectedItems: null, defaultSelectedItems: [items[6]] });
+
+  expect(
+    wrapper
+      .find('input')
+      .at(0)
+      .props().value
+  ).toBe(77);
+});


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [ ] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [ ] I have added unit tests to cover my changes;
- [ ] I updated the documentation and examples accordingly;

## Changes description

This PR adds two tests that check the switch between controlled and uncontrolled states of the dropdown component.

The second test is not passing, we should fix this issue.

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-dropdown

