### PR TITLE
feat: provides the original item as onChange argument at Dropdown

### DIFF
--- a/packages/react-dropdown/src/Items.js
+++ b/packages/react-dropdown/src/Items.js
@@ -18,10 +18,12 @@ import {
   type GetItemProps,
 } from './dropdownTypes.js';
 
+type DropdownItemWithIndex = DropdownItem & { index?: number };
+
 type Props = {
   categoryId?: number | string,
   twoColumn?: boolean,
-  items: Array<$Shape<DropdownItem & { index?: number }>>,
+  items: Array<$Shape<DropdownItemWithIndex>>,
   getItemProps: GetItemProps,
   inputValue: ?string,
   highlightedIndex: ?number,
@@ -100,11 +102,12 @@ export default function DropdownItems({
 }: Props) {
   return (
     <Items>
-      {items.map((item, index) => {
-        const itemIndex = item.hasOwnProperty('index') ? item.index : index;
+      {items.map((item, i) => {
+        const itemIndex = item.hasOwnProperty('index') ? item.index : i;
         const isHighlighted = itemIndex === highlightedIndex;
         const isSelected = includesId(selectedItems, item.id);
         const isDisabled = Boolean(item.disabled);
+        const { index, ...itemWithoutIndex } = item;
 
         return (
           <Item
@@ -115,10 +118,7 @@ export default function DropdownItems({
             twoColumn={twoColumn}
             {...getItemProps({
               index: itemIndex,
-              item: {
-                id: item.id,
-                label: item.label,
-              },
+              item: itemWithoutIndex,
               disabled: isDisabled,
             })}
           >

--- a/packages/react-dropdown/src/dropdownTypes.js
+++ b/packages/react-dropdown/src/dropdownTypes.js
@@ -36,6 +36,6 @@ export type DropdownSelectedItem = {
 };
 
 export type GetItemProps = $PropertyType<
-  PropGetters<DropdownSelectedItem>,
+  PropGetters<DropdownItem>,
   'getItemProps'
 >;

--- a/packages/react-dropdown/src/index.test.js
+++ b/packages/react-dropdown/src/index.test.js
@@ -131,7 +131,7 @@ it('onChanges gets called when selecting second value', () => {
     .simulate('click');
 
   expect(handleChange).toHaveBeenCalledWith(
-    [{ id: 22, label: 'Two' }],
+    [{ categoryId: 'a', id: 22, label: 'Two' }],
     expect.any(Object)
   );
 });
@@ -168,11 +168,11 @@ it('onChanges gets called when selecting first value', () => {
 
   expect(handleChange).toHaveBeenCalledTimes(2);
   expect(handleChange).toHaveBeenCalledWith(
-    [{ id: 10, label: 'One' }],
+    [{ categoryId: 'a', id: 10, label: 'One' }],
     expect.any(Object)
   );
   expect(handleChange).toHaveBeenCalledWith(
-    [{ id: 22, label: 'Two' }],
+    [{ categoryId: 'a', id: 22, label: 'Two' }],
     expect.any(Object)
   );
 });
@@ -203,7 +203,10 @@ it('multiselect should be visible in the onChange callback', () => {
 
   expect(handleChange).toHaveBeenCalledTimes(2);
   expect(handleChange).toHaveBeenCalledWith(
-    [{ id: 10, label: 'One' }, { id: 22, label: 'Two' }],
+    [
+      { categoryId: 'a', id: 10, label: 'One' },
+      { categoryId: 'a', id: 22, label: 'Two' },
+    ],
     expect.any(Object)
   );
 });
@@ -308,7 +311,7 @@ it('using arrow down and return key should select another element', () => {
   wrapper.find(Input).simulate('keyDown', { key: 'Enter', keyCode: 13 });
 
   expect(handleSelect).toHaveBeenCalledWith(
-    { id: 10, label: 'One' },
+    { categoryId: 'a', id: 10, label: 'One' },
     expect.any(Object)
   );
 });
@@ -369,7 +372,7 @@ it('Two clicks on the same item should call onChange twice, at the end nothing s
 
   expect(handleChange).toHaveBeenCalledTimes(2);
   expect(handleChange).toHaveBeenCalledWith(
-    [{ id: 10, label: 'One' }],
+    [{ categoryId: 'a', id: 10, label: 'One' }],
     expect.any(Object)
   );
   expect(handleChange).toHaveBeenCalledWith([], expect.any(Object));
@@ -605,7 +608,7 @@ it('onChange should be called with the newly selected items', () => {
     .simulate('click');
 
   expect(onChangeFn).toHaveBeenCalledWith(
-    [{ id: 22, label: 'Two' }],
+    [{ categoryId: 'a', id: 22, label: 'Two' }],
     expect.anything()
   );
 });


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description
Here is a simple test example what capability are we adding: [line 14](https://github.com/quid/refraction/blob/a1b2df91d67d06c8dfc17ed686694d8e570d55c9/packages/react-dropdown/src/index.test.js#L114)
 

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-dropdown

