### PR TITLE
fix: default Button to type=button

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 
 # Override default install command (it would run without --frozen-lockfile by default)
 install:
-  - yarn --frozen-lockfile
+  - yarn --frozen-lockfile --network-concurrency 1
 
 # Here we run all our tests
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: yarn
 
 # Upgrade Yarn
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.12.1
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
   - export PATH="$HOME/.yarn/bin:$PATH"
 
 # Override default install command (it would run without --frozen-lockfile by default)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: 11
+node_js: 11.10
 
 # We cache the node_modules and other Yarn related files to speed up the build
 cache: yarn

--- a/packages/react-core/src/Button/__snapshots__/index.test.js.snap
+++ b/packages/react-core/src/Button/__snapshots__/index.test.js.snap
@@ -74,9 +74,11 @@ exports[`renders a Button with small size 1`] = `
 <Button
   importance="secondary"
   size="small"
+  type="button"
 >
   <button
     className="emotion-0 emotion-1"
+    type="button"
   >
     Hello, World!
   </button>
@@ -167,10 +169,12 @@ exports[`renders a disabled and transparent Button 1`] = `
   importance="secondary"
   size="regular"
   transparent={true}
+  type="button"
 >
   <button
     className="emotion-0 emotion-1"
     disabled={true}
+    type="button"
   >
     Hello, World!
   </button>
@@ -251,10 +255,12 @@ exports[`renders the expected markup 1`] = `
   data-action="foo"
   importance="secondary"
   size="regular"
+  type="button"
 >
   <button
     className="emotion-0 emotion-1"
     data-action="foo"
+    type="button"
   >
     Hello, World!
   </button>

--- a/packages/react-core/src/Button/index.js
+++ b/packages/react-core/src/Button/index.js
@@ -46,6 +46,8 @@ type Props = {
   to?: string | Object,
   /** when `true`, the button can't be clicked */
   disabled?: boolean,
+  /** type to apply to the button HTMLelement when rendering a "real" button */
+  type?: 'button' | 'submit' | 'reset',
 };
 
 const hoverMod = color =>
@@ -70,7 +72,16 @@ const reset = css`
 `;
 
 const Button = styled(
-  ({ to, href, transparent, size, importance, disabled, ...props }: Props) => {
+  ({
+    to,
+    href,
+    transparent,
+    size,
+    importance,
+    disabled,
+    type,
+    ...props
+  }: Props) => {
     let Tag, specificProps;
     if (to && !disabled) {
       Tag = Link;
@@ -80,7 +91,7 @@ const Button = styled(
       specificProps = { href };
     } else {
       Tag = 'button';
-      specificProps = { disabled };
+      specificProps = { disabled, type };
     }
 
     return <Tag {...specificProps} {...props} />;
@@ -181,6 +192,7 @@ const Button = styled(
 Button.defaultProps = {
   importance: 'secondary',
   size: 'regular',
+  type: 'button',
 };
 
 // @component

--- a/packages/react-core/src/Button/index.test.js
+++ b/packages/react-core/src/Button/index.test.js
@@ -108,6 +108,11 @@ it('applies Button classes to child if child is Icon with near text', () => {
   ).toHaveLength(2);
 });
 
+it('renders a Button with type=submit', () => {
+  const wrapper = mount(<Button type="submit">Foobar</Button>);
+  expect(wrapper.find('button').props().type).toBe('submit');
+});
+
 // it('renders properly with isGroupChild property', () => {
 //   const wrapper = mount(<Button isGroupChild />);
 //   expect(wrapper).toMatchSnapshot();


### PR DESCRIPTION
This avoids accidental form submissions

<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

Fixes default button type

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-core
- @quid/react-date-picker (will fix bug with accidental submit on month change)

