### PR TITLE
fix: missing @quid/theme dependency

### DIFF
--- a/packages/react-date-picker/package.json
+++ b/packages/react-date-picker/package.json
@@ -24,6 +24,7 @@
     "@emotion/styled": "^10.0.6",
     "@emotion/styled-base": "^10.0.4",
     "@quid/react-core": "^1.36.1",
+    "@quid/theme": "^1.30.4",
     "date-fns": "^1.30.1",
     "emotion": "^10.0.6"
   },


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

There was a missing dependency, this PR should fix it.

I will prepare another PR where I add a new Travis CI step to simulate a publish process on PRs, this should make sure we don't encounter errors like this in future.

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-date-picker

