### PR TITLE
feat: add renderArrowIcon support to Breadcrumb

### DIFF
--- a/packages/react-layouts/src/Breadcrumb/__snapshots__/index.test.js.snap
+++ b/packages/react-layouts/src/Breadcrumb/__snapshots__/index.test.js.snap
@@ -33,6 +33,12 @@ exports[`renders a NavLink 1`] = `
 </NavLink>
 `;
 
+exports[`renders a custom arrowIcon 1`] = `
+<div>
+  0
+</div>
+`;
+
 exports[`renders a default NavLink 1`] = `
 .emotion-0 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
@@ -215,7 +221,7 @@ exports[`renders the expected markup 1`] = `
       disabled={false}
       emphasized={false}
       external={false}
-      key="0"
+      key=".0"
       to="/"
     >
       <ForwardRef(render)>
@@ -231,7 +237,7 @@ exports[`renders the expected markup 1`] = `
       </ForwardRef(render)>
     </NavLink>
     <Arrow
-      key="0_arrow"
+      key=".1"
     >
       <div
         className="emotion-5 emotion-6"
@@ -252,7 +258,7 @@ exports[`renders the expected markup 1`] = `
       disabled={false}
       emphasized={false}
       external={false}
-      key="1"
+      key=".2"
       to="/search"
     >
       <ForwardRef(render)>
@@ -272,7 +278,7 @@ exports[`renders the expected markup 1`] = `
       </ForwardRef(render)>
     </NavLink>
     <Arrow
-      key="1_arrow"
+      key=".3"
     >
       <div
         className="emotion-5 emotion-6"
@@ -293,7 +299,7 @@ exports[`renders the expected markup 1`] = `
       disabled={false}
       emphasized={false}
       external={false}
-      key="2"
+      key=".4"
       to="/search/review"
     >
       <ForwardRef(render)>
@@ -308,7 +314,7 @@ exports[`renders the expected markup 1`] = `
       </ForwardRef(render)>
     </NavLink>
     <Arrow
-      key="2_arrow"
+      key=".5"
     >
       <div
         className="emotion-5 emotion-6"
@@ -329,7 +335,7 @@ exports[`renders the expected markup 1`] = `
       disabled={true}
       emphasized={false}
       external={false}
-      key="3"
+      key=".6"
       to="/search/review/analyze"
     >
       <a
@@ -339,7 +345,7 @@ exports[`renders the expected markup 1`] = `
       </a>
     </NavLink>
     <Arrow
-      key="3_arrow"
+      key=".7"
     >
       <div
         className="emotion-5 emotion-6"
@@ -360,7 +366,7 @@ exports[`renders the expected markup 1`] = `
       disabled={false}
       emphasized={true}
       external={true}
-      key="4"
+      key=".8"
       to="/search/review/analyze/share"
     >
       <a

--- a/packages/react-layouts/src/Breadcrumb/index.js
+++ b/packages/react-layouts/src/Breadcrumb/index.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import NavLink from './NavLink';
 import { Icon } from '@quid/react-core';
 import styled from '@emotion/styled/macro';
@@ -16,6 +16,7 @@ export type Props = {
   items: Array<{
     label: React$Node,
     path: string,
+    renderArrowIcon?: ({ index: number }) => React.Node,
     arrowIcon?: string,
     disabled?: boolean,
     external?: boolean,
@@ -36,6 +37,7 @@ function genItem(
     label,
     path,
     arrowIcon = 'angle_right',
+    renderArrowIcon,
     disabled = false,
     external = false,
     emphasized = false,
@@ -49,7 +51,6 @@ function genItem(
       emphasized={emphasized}
       external={external}
       disabled={disabled}
-      key={index}
     >
       {tooltip ? (
         <span title={tooltip} id={`breadcrumb-${index}-tooltip`}>
@@ -59,17 +60,23 @@ function genItem(
         label
       )}
     </NavLink>,
-    <Arrow key={`${index}_arrow`}>
-      <Icon name={arrowIcon} />
-    </Arrow>,
+    renderArrowIcon ? (
+      renderArrowIcon({ index })
+    ) : (
+      <Arrow>
+        <Icon name={arrowIcon} />
+      </Arrow>
+    ),
   ];
 }
 
 const Breadcrumb = styled(({ items, ...props }: Props) => {
-  const processedItems = items
-    .map(genItem)
-    .reduce((a, b) => a.concat(b), [])
-    .slice(0, -1);
+  const processedItems = React.Children.toArray(
+    items
+      .map(genItem)
+      .reduce((a, b) => a.concat(b), [])
+      .slice(0, -1)
+  );
 
   return <ul {...props}>{processedItems}</ul>;
 })`

--- a/packages/react-layouts/src/Breadcrumb/index.js
+++ b/packages/react-layouts/src/Breadcrumb/index.js
@@ -26,6 +26,8 @@ export type Props = {
   className?: string,
 };
 
+const flatten = (a, b) => a.concat(b);
+
 const Arrow = styled.div`
   padding-left: ${sizes.regular};
   padding-right: ${sizes.regular};
@@ -73,9 +75,9 @@ function genItem(
 const Breadcrumb = styled(({ items, ...props }: Props) => {
   const processedItems = React.Children.toArray(
     items
-      .map(genItem)
-      .reduce((a, b) => a.concat(b), [])
-      .slice(0, -1)
+      .map(genItem) // generate couple of [[item, arrow], [item, arrow], ...]
+      .reduce(flatten, []) // flatten array
+      .slice(0, -1) // drop last item
   );
 
   return <ul {...props}>{processedItems}</ul>;

--- a/packages/react-layouts/src/Breadcrumb/index.test.js
+++ b/packages/react-layouts/src/Breadcrumb/index.test.js
@@ -69,3 +69,27 @@ it('renders a NavLink', () => {
 
   expect(wrapper).toMatchSnapshot();
 });
+
+it('renders a custom arrowIcon', () => {
+  const CustomArrow = ({ foo }) => <div>{foo}</div>;
+
+  const wrapper = mount(
+    <BrowserRouter>
+      <Breadcrumb
+        items={[
+          {
+            label: 'SHARE',
+            path: '/',
+            renderArrowIcon: ({ index }) => <CustomArrow foo={index} />,
+          },
+          {
+            label: 'FOO',
+            path: '/foo',
+          },
+        ]}
+      />
+    </BrowserRouter>
+  );
+
+  expect(wrapper.find(CustomArrow)).toMatchSnapshot();
+});


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

Adds support for a new `renderArrowIcon` property, that allows to define a render function that returns a custom separator node we want to use. It will take precedence over an existing `arrowIcon` property.

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-layouts

