### PR TITLE
feat: move merge-refs to a dedicated package

### DIFF
--- a/packages/merge-refs/README.md
+++ b/packages/merge-refs/README.md
@@ -1,0 +1,48 @@
+`merge-refs` is a little utility used to call different
+React ["refs"][react-refs] all at once.
+
+It can be especially useful if you are using two or more libraries
+that need a reference of the same React component.
+
+## Installation
+
+```bash
+npm install --save @quid/merge-refs
+
+# or
+
+yarn add @quid/merge-refs
+```
+
+## Usage
+
+A typical use case is:
+
+```jsx static
+import mergeRefs from '@quid/merge-refs';
+
+<Popper>
+  {({ ref, style }) => (
+    <MouseOutside>
+      {ref2 => (
+        <div style={style} ref={mergeRefs(ref, ref2)}>
+          content
+        </div>
+      )}
+    </MouseOutside>
+  )}
+</Popper>;
+```
+
+Or, with React hooks:
+
+```jsx static
+import mergeRefs from '@quid/merge-refs';
+
+const ref1 = useRef(null);
+const ref2 = useRef(null);
+
+<div ref={mergeRefs(ref1, ref2)} />;
+```
+
+[react-refs]: https://reactjs.org/docs/refs-and-the-dom.html

--- a/packages/merge-refs/package.json
+++ b/packages/merge-refs/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@quid/merge-refs",
+  "version": "1.0.0",
+  "description": "Utility to merge different React “refs” into a single call.",
+  "main": "dist/index.js",
+  "main:umd": "dist/index.umd.js",
+  "module": "dist/index.es.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/quid/refraction/tree/master/packages/merge-refs"
+  },
+  "scripts": {
+    "start": "microbundle watch",
+    "prepare": "microbundle build --jsx React.createElement && flow-copy-source --ignore '{__mocks__/*,*.test}.js' src dist",
+    "test": "cd ../.. && yarn test --testPathPattern packages/merge-refs"
+  },
+  "devDependencies": {
+    "flow-copy-source": "^2.0.2",
+    "microbundle": "^0.8.3",
+    "react": "^16.0.0"
+  },
+  "peerDependencies": {
+    "react": "15||16"
+  }
+}

--- a/packages/merge-refs/src/index.js
+++ b/packages/merge-refs/src/index.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 // @flow
-export default (...refs: Array<any>) => (ref: any) => {
+const mergeRefs = (...refs: Array<any>) => (ref: any) => {
   refs.forEach(resolvableRef => {
     if (typeof resolvableRef === 'function') {
       resolvableRef(ref);
@@ -14,3 +14,5 @@ export default (...refs: Array<any>) => (ref: any) => {
     }
   });
 };
+
+export default mergeRefs;

--- a/packages/merge-refs/src/index.test.js
+++ b/packages/merge-refs/src/index.test.js
@@ -6,7 +6,7 @@
  */
 // @flow
 import * as React from 'react';
-import mergeRefs from './mergeRefs';
+import mergeRefs from '.';
 
 it('merges two React refs', () => {
   const ref = document.createElement('div');

--- a/packages/react-forms/package.json
+++ b/packages/react-forms/package.json
@@ -20,6 +20,7 @@
     "@emotion/css": "^10.0.4",
     "@emotion/styled": "^10.0.2",
     "@emotion/styled-base": "^10.0.4",
+    "@quid/merge-refs": "^1.0.0",
     "@quid/react-core": "^1.36.1",
     "@quid/react-date-picker": "^1.36.2",
     "@quid/react-invalid-handler": "^1.26.0",

--- a/packages/react-forms/src/InputDate/index.js
+++ b/packages/react-forms/src/InputDate/index.js
@@ -12,7 +12,7 @@ import InputText from '../InputText';
 import Calendar from '@quid/react-date-picker';
 import { Icon } from '@quid/react-core';
 import MouseOutside from '@quid/react-mouse-outside';
-import mergeRefs from '../utils/mergeRefs';
+import mergeRefs from '@quid/merge-refs';
 
 function toYYYYMMDD(date) {
   const day = ('0' + date.getDate()).slice(-2);

--- a/packages/react-forms/src/InputFile/index.js
+++ b/packages/react-forms/src/InputFile/index.js
@@ -8,7 +8,7 @@
 import * as React from 'react';
 import styled from '@emotion/styled/macro';
 import callAll from '../utils/callAll';
-import mergeRefs from '../utils/mergeRefs';
+import mergeRefs from '@quid/merge-refs';
 import InputGroup from '../InputGroup';
 import InputText from '../InputText';
 import Button from '../Button';

--- a/packages/react-forms/src/InputText/index.js
+++ b/packages/react-forms/src/InputText/index.js
@@ -11,7 +11,7 @@ import { ClassNames } from '@emotion/core';
 import { textStyles, withFallback as wf } from '@quid/theme';
 import InvalidHandler from '@quid/react-invalid-handler';
 import { INPUT_ATTRIBUTES, omit, include } from '../utils/inputPropsFilters';
-import mergeRefs from '../utils/mergeRefs';
+import mergeRefs from '@quid/merge-refs';
 
 type RenderProp<P> = P => React.Node;
 

--- a/src/badges.json
+++ b/src/badges.json
@@ -1,5 +1,6 @@
 {
   "oss": [
+    "merge-refs",
     "react-ellipsis",
     "react-invalid-handler",
     "react-mouse-outside",


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

Publish `merge-refs` from its own package, so that we can reuse it easily between projects.

## Affected packages

<!-- List below all the affected packages -->

- @quid/merge-refs
- @quid/react-forms

