### PR TITLE
fix: set all packages to public by default

### DIFF
--- a/packages/merge-refs/package.json
+++ b/packages/merge-refs/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/quid/refraction/tree/master/packages/merge-refs"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "start": "microbundle watch",
     "prepare": "microbundle build --jsx React.createElement && flow-copy-source --ignore '{__mocks__/*,*.test}.js' src dist",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/quid/refraction/tree/master/packages/react-core"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "start": "microbundle watch",
     "prepare": "microbundle build --jsx React.createElement && flow-copy-source --ignore '{__mocks__/*,*.test}.js' src dist",

--- a/packages/react-date-picker/package.json
+++ b/packages/react-date-picker/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/quid/refraction/tree/master/packages/react-date-picker"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "start": "microbundle watch",
     "prepare": "microbundle build --jsx React.createElement && flow-copy-source --ignore '{__mocks__/*,*.test}.js' src dist",

--- a/packages/react-dropdown/package.json
+++ b/packages/react-dropdown/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/quid/ui-framework.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "start": "microbundle watch",
     "prepare": "microbundle build --jsx React.createElement && flow-copy-source --ignore '{__mocks__/*,*.test}.js' src dist",

--- a/packages/react-ellipsis/package.json
+++ b/packages/react-ellipsis/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/quid/refraction/tree/master/packages/react-ellipsis"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "start": "microbundle watch",
     "prepare": "microbundle build --jsx React.createElement && flow-copy-source --ignore '{__mocks__/*,*.test}.js' src dist",

--- a/packages/react-forms/package.json
+++ b/packages/react-forms/package.json
@@ -15,6 +15,9 @@
     "prepare": "microbundle build --jsx React.createElement && flow-copy-source --ignore '{__mocks__/*,*.test}.js' src dist",
     "test": "cd ../.. && yarn test --testPathPattern packages/react-forms"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@emotion/core": "^10.0.4",
     "@emotion/css": "^10.0.4",

--- a/packages/react-invalid-handler/package.json
+++ b/packages/react-invalid-handler/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/quid/refraction/tree/master/packages/react-invalid-handler"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "start": "microbundle watch",
     "prepare": "microbundle build --jsx React.createElement && flow-copy-source --ignore '{__mocks__/*,*.test}.js' src dist",

--- a/packages/react-layouts/package.json
+++ b/packages/react-layouts/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/quid/refraction/tree/master/packages/react-layouts"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "start": "microbundle watch",
     "prepare": "microbundle build --jsx React.createElement && flow-copy-source --ignore '{__mocks__/*,*.test}.js' src dist",

--- a/packages/react-mouse-outside/package.json
+++ b/packages/react-mouse-outside/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/quid/refraction/tree/master/packages/react-mouse-outside"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "start": "microbundle watch",
     "prepare": "microbundle build --jsx React.createElement && flow-copy-source --ignore '{__mocks__/*,*.test}.js' src dist",

--- a/packages/react-package-template/init/package.json
+++ b/packages/react-package-template/init/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/quid/refraction/tree/master/packages/<%= packageName %>"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "start": "microbundle watch",
     "prepare": "microbundle build --jsx React.createElement && flow-copy-source --ignore '{__mocks__/*,*.test}.js' src dist",

--- a/packages/react-tabs-provider/package.json
+++ b/packages/react-tabs-provider/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/quid/refraction/tree/master/packages/react-tabs-provider"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "start": "microbundle watch",
     "prepare": "microbundle build --jsx React.createElement && flow-copy-source --ignore '{__mocks__/*,*.test}.js' src dist",

--- a/packages/stylis-plugin-focus-visible/package.json
+++ b/packages/stylis-plugin-focus-visible/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "https://github.com/quid/refraction/tree/master/packages/stylis-plugin-focus-visible"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "start": "microbundle watch",
     "prepare": "microbundle build --jsx React.createElement && flow-copy-source --ignore '{__mocks__/*,*.test}.js' src dist",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -6,6 +6,9 @@
   "main:umd": "dist/index.umd.js",
   "module": "dist/index.es.js",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "start": "microbundle watch",
     "prepare": "microbundle build --jsx React.createElement && flow-copy-source --ignore '{__mocks__/*,*.test}.js' src dist",


### PR DESCRIPTION

<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

All our packages had been publish manually the first time because we previously hosted them on the internal registry.

Now, new packages, when published for the first time, required the access to be set to public to not fail the publish step.

This will fix the failed merge-refs publish.

## Affected packages

<!-- List below all the affected packages -->

- @quid/merge-refs

