### PR TITLE
fix: modal overlay issue

### DIFF
--- a/packages/react-layouts/src/Modal/index.js
+++ b/packages/react-layouts/src/Modal/index.js
@@ -96,8 +96,12 @@ const Modal = styled(
                 left: 0;
                 right: 0;
                 bottom: 0;
-                background-color: ${wf(({ theme }) =>
-                  reduceOpacity(theme.colors.black, 0.6)
+                ${wf(
+                  ({ theme }) =>
+                    `background-color: ${reduceOpacity(
+                      theme.colors.black,
+                      0.6
+                    )}`
                 )({ theme })};
               `,
               overlayClassName


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

Fixes an issue with the modal overlay, when used in consumer projects, the overlay didn't have a background color.

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-layouts

