### PR TITLE
perf: reduce time to first render with font-display: swap

### DIFF
--- a/packages/theme/fonts/ibmplex/index.css
+++ b/packages/theme/fonts/ibmplex/index.css
@@ -2,6 +2,7 @@
   font-family: 'IBM Plex Sans';
   font-weight: 400;
   font-style: normal;
+  font-display: swap;
   src: url('ibmplexsans-regular-webfont.woff2') format('woff2'),
     url('ibmplexsans-regular-webfont.woff') format('woff');
 }
@@ -10,6 +11,7 @@
   font-family: 'IBM Plex Sans';
   font-weight: 400;
   font-style: italic;
+  font-display: swap;
   src: url('ibmplexsans-italic-webfont.woff2') format('woff2'),
     url('ibmplexsans-italic-webfont.woff') format('woff');
 }
@@ -18,6 +20,7 @@
   font-family: 'IBM Plex Sans';
   font-weight: 700;
   font-style: normal;
+  font-display: swap;
   src: url('ibmplexsans-semibold-webfont.woff2') format('woff2'),
     url('ibmplexsans-semibold-webfont.woff') format('woff');
 }
@@ -26,6 +29,7 @@
   font-family: 'IBM Plex Sans';
   font-weight: 700;
   font-style: italic;
+  font-display: swap;
   src: url('ibmplexsans-semibolditalic-webfont.woff2') format('woff2'),
     url('ibmplexsans-semibolditalic-webfont.woff') format('woff');
 }
@@ -34,6 +38,7 @@
   font-family: 'IBM Plex Serif';
   font-weight: 400;
   font-style: normal;
+  font-display: swap;
   src: url('ibmplexserif-regular-webfont.woff2') format('woff2'),
     url('ibmplexserif-regular-webfont.woff') format('woff');
 }
@@ -42,6 +47,7 @@
   font-family: 'IBM Plex Serif';
   font-weight: 400;
   font-style: italic;
+  font-display: swap;
   src: url('ibmplexserif-italic-webfont.woff2') format('woff2'),
     url('ibmplexserif-italic-webfont.woff') format('woff');
 }
@@ -50,6 +56,7 @@
   font-family: 'IBM Plex Serif';
   font-weight: 700;
   font-style: normal;
+  font-display: swap;
   src: url('ibmplexserif-semibold-webfont.woff2') format('woff2'),
     url('ibmplexserif-semibold-webfont.woff') format('woff');
 }
@@ -58,6 +65,7 @@
   font-family: 'IBM Plex Serif';
   font-weight: 700;
   font-style: italic;
+  font-display: swap;
   src: url('ibmplexserif-semibolditalic-webfont.woff2') format('woff2'),
     url('ibmplexserif-semibolditalic-webfont.woff') format('woff');
 }

--- a/packages/theme/fonts/icons/index.css
+++ b/packages/theme/fonts/icons/index.css
@@ -5,4 +5,5 @@
     url('quid-icons.svg#quid-icons') format('svg');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

I changed the `font-display` value to `swap` (rather than `auto`), this should reduce the time to first render.

The idea came from [this tweet](https://twitter.com/samccone/status/1106979581876035584)

## Affected packages

<!-- List below all the affected packages -->

- @quid/theme

