### PR TITLE
fix: modal backdrop missing semicolon

### DIFF
--- a/packages/react-layouts/src/Modal/index.js
+++ b/packages/react-layouts/src/Modal/index.js
@@ -101,8 +101,8 @@ const Modal = styled(
                     `background-color: ${reduceOpacity(
                       theme.colors.black,
                       0.6
-                    )}`
-                )({ theme })};
+                    )};`
+                )({ theme })}
               `,
               overlayClassName
             )}


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

The semicolon was in the wrong position and was stripped out when the bundle was compiled.

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-layouts

