### PR TITLE
Feat dropdown change dark theme colors

### DIFF
--- a/packages/react-dropdown/package.json
+++ b/packages/react-dropdown/package.json
@@ -30,6 +30,7 @@
     "@emotion/core": "^10.0.6",
     "@emotion/css": "^10.0.6",
     "@emotion/styled": "^10.0.6",
+    "@emotion/styled-base": "10.0.4",
     "@quid/react-core": "^1.38.6",
     "@quid/theme": "^1.38.6",
     "color": "^3.1.0",

--- a/packages/react-dropdown/src/Items.js
+++ b/packages/react-dropdown/src/Items.js
@@ -45,10 +45,7 @@ export const HIGHLIGHTED = (props: { theme: Object }) =>
     ? props.theme.colors.gray1
     : props.theme.colors.gray5;
 
-export const SELECTED = (props: { theme: Object }) =>
-  props.theme.current === 'light'
-    ? props.theme.colors.gray3
-    : props.theme.colors.gray1;
+export const SELECTED = (props: { theme: Object }) => props.theme.colors.gray3;
 
 export const Item = styled.li`
   display: flex;

--- a/packages/react-dropdown/src/__snapshots__/index.test.js.snap
+++ b/packages/react-dropdown/src/__snapshots__/index.test.js.snap
@@ -481,7 +481,7 @@ exports[`renders an open dropdown with categories 1`] = `
                                 id="downshift-3-item-0"
                                 isHighlighted={false}
                                 isSelected={false}
-                                key="22"
+                                key="10"
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
                                 onMouseMove={[Function]}
@@ -501,13 +501,13 @@ exports[`renders an open dropdown with categories 1`] = `
                                   <HighlightValue
                                     disabled={false}
                                     highlight={false}
-                                    value="Two"
+                                    value="One"
                                     valueToHighlight=""
                                   >
                                     <span
                                       className="emotion-4 emotion-5"
                                     >
-                                      Two
+                                      One
                                     </span>
                                   </HighlightValue>
                                 </li>
@@ -519,7 +519,7 @@ exports[`renders an open dropdown with categories 1`] = `
                                 id="downshift-3-item-1"
                                 isHighlighted={false}
                                 isSelected={false}
-                                key="10"
+                                key="22"
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
                                 onMouseMove={[Function]}
@@ -539,13 +539,13 @@ exports[`renders an open dropdown with categories 1`] = `
                                   <HighlightValue
                                     disabled={false}
                                     highlight={false}
-                                    value="One"
+                                    value="Two"
                                     valueToHighlight=""
                                   >
                                     <span
                                       className="emotion-4 emotion-5"
                                     >
-                                      One
+                                      Two
                                     </span>
                                   </HighlightValue>
                                 </li>
@@ -604,7 +604,7 @@ exports[`renders an open dropdown with categories 1`] = `
                                 id="downshift-3-item-2"
                                 isHighlighted={false}
                                 isSelected={false}
-                                key="44"
+                                key="33"
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
                                 onMouseMove={[Function]}
@@ -624,13 +624,13 @@ exports[`renders an open dropdown with categories 1`] = `
                                   <HighlightValue
                                     disabled={false}
                                     highlight={false}
-                                    value="Four"
+                                    value="Three"
                                     valueToHighlight=""
                                   >
                                     <span
                                       className="emotion-4 emotion-5"
                                     >
-                                      Four
+                                      Three
                                     </span>
                                   </HighlightValue>
                                 </li>
@@ -642,7 +642,7 @@ exports[`renders an open dropdown with categories 1`] = `
                                 id="downshift-3-item-3"
                                 isHighlighted={false}
                                 isSelected={false}
-                                key="33"
+                                key="44"
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
                                 onMouseMove={[Function]}
@@ -662,13 +662,13 @@ exports[`renders an open dropdown with categories 1`] = `
                                   <HighlightValue
                                     disabled={false}
                                     highlight={false}
-                                    value="Three"
+                                    value="Four"
                                     valueToHighlight=""
                                   >
                                     <span
                                       className="emotion-4 emotion-5"
                                     >
-                                      Three
+                                      Four
                                     </span>
                                   </HighlightValue>
                                 </li>
@@ -938,7 +938,7 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                                   id="downshift-4-item-0"
                                   isHighlighted={false}
                                   isSelected={false}
-                                  key="22"
+                                  key="10"
                                   onClick={[Function]}
                                   onMouseDown={[Function]}
                                   onMouseMove={[Function]}
@@ -958,13 +958,13 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                                     <HighlightValue
                                       disabled={false}
                                       highlight={false}
-                                      value="Two"
+                                      value="One"
                                       valueToHighlight=""
                                     >
                                       <span
                                         className="emotion-4 emotion-5"
                                       >
-                                        Two
+                                        One
                                       </span>
                                     </HighlightValue>
                                   </li>
@@ -976,7 +976,7 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                                   id="downshift-4-item-1"
                                   isHighlighted={false}
                                   isSelected={false}
-                                  key="10"
+                                  key="22"
                                   onClick={[Function]}
                                   onMouseDown={[Function]}
                                   onMouseMove={[Function]}
@@ -996,13 +996,13 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                                     <HighlightValue
                                       disabled={false}
                                       highlight={false}
-                                      value="One"
+                                      value="Two"
                                       valueToHighlight=""
                                     >
                                       <span
                                         className="emotion-4 emotion-5"
                                       >
-                                        One
+                                        Two
                                       </span>
                                     </HighlightValue>
                                   </li>
@@ -1061,7 +1061,7 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                                   id="downshift-4-item-2"
                                   isHighlighted={false}
                                   isSelected={false}
-                                  key="44"
+                                  key="33"
                                   onClick={[Function]}
                                   onMouseDown={[Function]}
                                   onMouseMove={[Function]}
@@ -1081,13 +1081,13 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                                     <HighlightValue
                                       disabled={false}
                                       highlight={false}
-                                      value="Four"
+                                      value="Three"
                                       valueToHighlight=""
                                     >
                                       <span
                                         className="emotion-4 emotion-5"
                                       >
-                                        Four
+                                        Three
                                       </span>
                                     </HighlightValue>
                                   </li>
@@ -1099,7 +1099,7 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                                   id="downshift-4-item-3"
                                   isHighlighted={false}
                                   isSelected={false}
-                                  key="33"
+                                  key="44"
                                   onClick={[Function]}
                                   onMouseDown={[Function]}
                                   onMouseMove={[Function]}
@@ -1119,13 +1119,13 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                                     <HighlightValue
                                       disabled={false}
                                       highlight={false}
-                                      value="Three"
+                                      value="Four"
                                       valueToHighlight=""
                                     >
                                       <span
                                         className="emotion-4 emotion-5"
                                       >
-                                        Three
+                                        Four
                                       </span>
                                     </HighlightValue>
                                   </li>

--- a/packages/react-dropdown/src/__snapshots__/index.test.js.snap
+++ b/packages/react-dropdown/src/__snapshots__/index.test.js.snap
@@ -481,7 +481,7 @@ exports[`renders an open dropdown with categories 1`] = `
                                 id="downshift-3-item-0"
                                 isHighlighted={false}
                                 isSelected={false}
-                                key="10"
+                                key="22"
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
                                 onMouseMove={[Function]}
@@ -501,13 +501,13 @@ exports[`renders an open dropdown with categories 1`] = `
                                   <HighlightValue
                                     disabled={false}
                                     highlight={false}
-                                    value="One"
+                                    value="Two"
                                     valueToHighlight=""
                                   >
                                     <span
                                       className="emotion-4 emotion-5"
                                     >
-                                      One
+                                      Two
                                     </span>
                                   </HighlightValue>
                                 </li>
@@ -519,7 +519,7 @@ exports[`renders an open dropdown with categories 1`] = `
                                 id="downshift-3-item-1"
                                 isHighlighted={false}
                                 isSelected={false}
-                                key="22"
+                                key="10"
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
                                 onMouseMove={[Function]}
@@ -539,13 +539,13 @@ exports[`renders an open dropdown with categories 1`] = `
                                   <HighlightValue
                                     disabled={false}
                                     highlight={false}
-                                    value="Two"
+                                    value="One"
                                     valueToHighlight=""
                                   >
                                     <span
                                       className="emotion-4 emotion-5"
                                     >
-                                      Two
+                                      One
                                     </span>
                                   </HighlightValue>
                                 </li>
@@ -604,7 +604,7 @@ exports[`renders an open dropdown with categories 1`] = `
                                 id="downshift-3-item-2"
                                 isHighlighted={false}
                                 isSelected={false}
-                                key="33"
+                                key="44"
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
                                 onMouseMove={[Function]}
@@ -624,13 +624,13 @@ exports[`renders an open dropdown with categories 1`] = `
                                   <HighlightValue
                                     disabled={false}
                                     highlight={false}
-                                    value="Three"
+                                    value="Four"
                                     valueToHighlight=""
                                   >
                                     <span
                                       className="emotion-4 emotion-5"
                                     >
-                                      Three
+                                      Four
                                     </span>
                                   </HighlightValue>
                                 </li>
@@ -642,7 +642,7 @@ exports[`renders an open dropdown with categories 1`] = `
                                 id="downshift-3-item-3"
                                 isHighlighted={false}
                                 isSelected={false}
-                                key="44"
+                                key="33"
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
                                 onMouseMove={[Function]}
@@ -662,13 +662,13 @@ exports[`renders an open dropdown with categories 1`] = `
                                   <HighlightValue
                                     disabled={false}
                                     highlight={false}
-                                    value="Four"
+                                    value="Three"
                                     valueToHighlight=""
                                   >
                                     <span
                                       className="emotion-4 emotion-5"
                                     >
-                                      Four
+                                      Three
                                     </span>
                                   </HighlightValue>
                                 </li>
@@ -938,7 +938,7 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                                   id="downshift-4-item-0"
                                   isHighlighted={false}
                                   isSelected={false}
-                                  key="10"
+                                  key="22"
                                   onClick={[Function]}
                                   onMouseDown={[Function]}
                                   onMouseMove={[Function]}
@@ -958,13 +958,13 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                                     <HighlightValue
                                       disabled={false}
                                       highlight={false}
-                                      value="One"
+                                      value="Two"
                                       valueToHighlight=""
                                     >
                                       <span
                                         className="emotion-4 emotion-5"
                                       >
-                                        One
+                                        Two
                                       </span>
                                     </HighlightValue>
                                   </li>
@@ -976,7 +976,7 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                                   id="downshift-4-item-1"
                                   isHighlighted={false}
                                   isSelected={false}
-                                  key="22"
+                                  key="10"
                                   onClick={[Function]}
                                   onMouseDown={[Function]}
                                   onMouseMove={[Function]}
@@ -996,13 +996,13 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                                     <HighlightValue
                                       disabled={false}
                                       highlight={false}
-                                      value="Two"
+                                      value="One"
                                       valueToHighlight=""
                                     >
                                       <span
                                         className="emotion-4 emotion-5"
                                       >
-                                        Two
+                                        One
                                       </span>
                                     </HighlightValue>
                                   </li>
@@ -1061,7 +1061,7 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                                   id="downshift-4-item-2"
                                   isHighlighted={false}
                                   isSelected={false}
-                                  key="33"
+                                  key="44"
                                   onClick={[Function]}
                                   onMouseDown={[Function]}
                                   onMouseMove={[Function]}
@@ -1081,13 +1081,13 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                                     <HighlightValue
                                       disabled={false}
                                       highlight={false}
-                                      value="Three"
+                                      value="Four"
                                       valueToHighlight=""
                                     >
                                       <span
                                         className="emotion-4 emotion-5"
                                       >
-                                        Three
+                                        Four
                                       </span>
                                     </HighlightValue>
                                   </li>
@@ -1099,7 +1099,7 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                                   id="downshift-4-item-3"
                                   isHighlighted={false}
                                   isSelected={false}
-                                  key="44"
+                                  key="33"
                                   onClick={[Function]}
                                   onMouseDown={[Function]}
                                   onMouseMove={[Function]}
@@ -1119,13 +1119,13 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                                     <HighlightValue
                                       disabled={false}
                                       highlight={false}
-                                      value="Four"
+                                      value="Three"
                                       valueToHighlight=""
                                     >
                                       <span
                                         className="emotion-4 emotion-5"
                                       >
-                                        Four
+                                        Three
                                       </span>
                                     </HighlightValue>
                                   </li>

--- a/packages/react-dropdown/src/index.test.js
+++ b/packages/react-dropdown/src/index.test.js
@@ -131,7 +131,7 @@ it('onChanges gets called when selecting second value', () => {
     .simulate('click');
 
   expect(handleChange).toHaveBeenCalledWith(
-    [{ categoryId: 'a', id: 22, label: 'Two' }],
+    [{ categoryId: 'a', id: 10, label: 'One' }],
     expect.any(Object)
   );
 });
@@ -498,9 +498,9 @@ it('supports dark theme', () => {
 
   expect(
     SELECTED({
-      theme: { current: 'dark', colors: { gray1: 'gray1' } },
+      theme: { current: 'dark', colors: { gray3: 'gray3' } },
     })
-  ).toBe('gray1');
+  ).toBe('gray3');
 
   expect(
     mount(

--- a/packages/react-dropdown/src/index.test.js
+++ b/packages/react-dropdown/src/index.test.js
@@ -131,7 +131,7 @@ it('onChanges gets called when selecting second value', () => {
     .simulate('click');
 
   expect(handleChange).toHaveBeenCalledWith(
-    [{ categoryId: 'a', id: 10, label: 'One' }],
+    [{ categoryId: 'a', id: 22, label: 'Two' }],
     expect.any(Object)
   );
 });

--- a/packages/react-forms/src/InputDate/__snapshots__/index.test.js.snap
+++ b/packages/react-forms/src/InputDate/__snapshots__/index.test.js.snap
@@ -40,6 +40,8 @@ exports[`renders the expected markup 1`] = `
   border: 0;
   font-family: inherit;
   font-size: inherit;
+  background-color: transparent;
+  color: inherit;
   min-width: 0;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;

--- a/packages/react-forms/src/InputText/__snapshots__/index.test.js.snap
+++ b/packages/react-forms/src/InputText/__snapshots__/index.test.js.snap
@@ -43,6 +43,8 @@ exports[`renders the expected markup 1`] = `
   border: 0;
   font-family: inherit;
   font-size: inherit;
+  background-color: transparent;
+  color: inherit;
   min-width: 0;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;

--- a/packages/react-forms/src/InputText/index.js
+++ b/packages/react-forms/src/InputText/index.js
@@ -47,6 +47,8 @@ export const Input = styled.input`
   border: 0;
   font-family: inherit;
   font-size: inherit;
+  background-color: transparent;
+  color: inherit;
 
   min-width: 0;
   align-self: stretch;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1174,7 +1174,7 @@
     "@emotion/utils" "0.11.1"
     object-assign "^4.1.1"
 
-"@emotion/styled-base@^10.0.4":
+"@emotion/styled-base@10.0.4", "@emotion/styled-base@^10.0.4":
   version "10.0.4"
   resolved "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.4.tgz#7b8243755a9757f4a0f5504b6b3431c84a0008e2"
   integrity sha512-GQl1nv31ASgjCt0FVR/0NyjXXZXuYVDjgrpNi1bPNosSwAKKAMddqJtt6X/f6A2KhmCfresDjscXs5NrdgKAGA==
@@ -9265,7 +9265,7 @@ metric-lcs@^0.1.2:
   resolved "https://registry.npmjs.org/metric-lcs/-/metric-lcs-0.1.2.tgz#87913f149410e39c7c5a19037512814eaf155e11"
   integrity sha512-+TZ5dUDPKPJaU/rscTzxyN8ZkX7eAVLAiQU/e+YINleXPv03SCmJShaMT1If1liTH8OcmWXZs0CmzCBRBLcMpA==
 
-microbundle@^0.8.3, "microbundle@https://github.com/FezVrasta/microbundle.git#quid-fork":
+microbundle@^0.8.3:
   version "0.8.3"
   resolved "https://github.com/FezVrasta/microbundle.git#834297a3134eaf24e0cc35da60812a53b2aef96b"
   dependencies:


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

Change the styling colors of the react-dropdown to component to match the Quid UI [style guide](https://www.figma.com/file/LS5LEaS62tZITxOpSpDBXEeG/Master?node-id=70%3A10) more closely. 

Before: 
![Screen Shot 2019-04-09 at 2 32 46 PM](https://user-images.githubusercontent.com/16729079/55837342-f404cd00-5ad5-11e9-8545-492d43c346b3.png)

After: 
![Screen Shot 2019-04-10 at 9 00 14 AM](https://user-images.githubusercontent.com/16729079/55894520-17c82180-5b6f-11e9-93db-e6231f1e4153.png)

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-dropdown

