### PR TITLE
feat: react-popover

### DIFF
--- a/packages/react-core/src/Button/__snapshots__/index.test.js.snap
+++ b/packages/react-core/src/Button/__snapshots__/index.test.js.snap
@@ -72,16 +72,19 @@ exports[`renders a Button with small size 1`] = `
   size="small"
   type="button"
 >
-  <button
+  <ForwardRef
     className="emotion-0 emotion-1"
+    importance="secondary"
+    size="small"
     type="button"
   >
-    <span
-      key=".0"
+    <button
+      className="emotion-0 emotion-1"
+      type="button"
     >
       Hello, World!
-    </span>
-  </button>
+    </button>
+  </ForwardRef>
 </Button>
 `;
 
@@ -168,17 +171,22 @@ exports[`renders a disabled and transparent Button 1`] = `
   transparent={true}
   type="button"
 >
-  <button
+  <ForwardRef
     className="emotion-0 emotion-1"
     disabled={true}
+    importance="secondary"
+    size="regular"
+    transparent={true}
     type="button"
   >
-    <span
-      key=".0"
+    <button
+      className="emotion-0 emotion-1"
+      disabled={true}
+      type="button"
     >
       Hello, World!
-    </span>
-  </button>
+    </button>
+  </ForwardRef>
 </Button>
 `;
 
@@ -255,16 +263,20 @@ exports[`renders the expected markup 1`] = `
   size="regular"
   type="button"
 >
-  <button
+  <ForwardRef
     className="emotion-0 emotion-1"
     data-action="foo"
+    importance="secondary"
+    size="regular"
     type="button"
   >
-    <span
-      key=".0"
+    <button
+      className="emotion-0 emotion-1"
+      data-action="foo"
+      type="button"
     >
       Hello, World!
-    </span>
-  </button>
+    </button>
+  </ForwardRef>
 </Button>
 `;

--- a/packages/react-core/src/Button/index.js
+++ b/packages/react-core/src/Button/index.js
@@ -72,41 +72,35 @@ const reset = css`
 `;
 
 const Button = styled(
-  ({
-    to,
-    href,
-    transparent,
-    size,
-    importance,
-    disabled,
-    type,
-    children,
-    ...props
-  }: Props) => {
-    let Tag, specificProps;
-    if (to && !disabled) {
-      Tag = Link;
-      specificProps = { to };
-    } else if ((href || to) && !disabled) {
-      Tag = 'a';
-      specificProps = { href };
-    } else {
-      Tag = 'button';
-      specificProps = { disabled, type };
-    }
+  React.forwardRef(
+    (
+      {
+        to,
+        href,
+        transparent,
+        size,
+        importance,
+        disabled,
+        type,
+        ...props
+      }: Props,
+      ref: React.ElementRef<any>
+    ) => {
+      let Tag, specificProps;
+      if (to && !disabled) {
+        Tag = Link;
+        specificProps = { to };
+      } else if ((href || to) && !disabled) {
+        Tag = 'a';
+        specificProps = { href };
+      } else {
+        Tag = 'button';
+        specificProps = { disabled, type };
+      }
 
-    return (
-      <Tag {...specificProps} {...props}>
-        {React.Children.map(children, node =>
-          ['string', 'number'].includes(typeof node) ? (
-            <span>{node}</span>
-          ) : (
-            node
-          )
-        )}
-      </Tag>
-    );
-  }
+      return <Tag {...specificProps} {...props} ref={ref} />;
+    }
+  )
 )`
   ${reset};
 

--- a/packages/react-popover/README.md
+++ b/packages/react-popover/README.md
@@ -1,0 +1,31 @@
+`@quid/react-popover` is a React component based upon `react-popper`,
+used to quickly create popovers in your applications.
+
+It supports all the advanced positioning provided by `react-popper`,
+a "click outside" detection system to automatically close the popover
+whenever the user clicks outside of it, and a render-props based API
+to allow full customization of the component rendering.
+
+As convenience utility, a `Container` component is exported from the paclage
+
+## Installation
+
+```bash
+npm install --save @quid/react-popover
+
+# or
+
+yarn add @quid/react-popover
+```
+
+<!--
+Preserve the text below to show the documentation URL on the npm page.
+You can use the "NPM_ONLY> ... <NPM_ONLY" delimiter to hide any text
+from the ui.quid.com documentation but keep it visible on the npm page.
+-->
+
+<!-- NPM_ONLY> -->
+
+More documentation is available at https://ui.quid.com
+
+<!-- <NPM_ONLY -->

--- a/packages/react-popover/package.json
+++ b/packages/react-popover/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@quid/react-popover",
+  "version": "1.0.0",
+  "description": "Popover component based on react-popper",
+  "main": "dist/index.js",
+  "main:umd": "dist/index.umd.js",
+  "module": "dist/index.es.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/quid/refraction/tree/master/packages/react-popover"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "start": "microbundle watch",
+    "prepare": "microbundle build --jsx React.createElement && flow-copy-source --ignore '{__mocks__/*,*.test}.js' src dist",
+    "test": "cd ../.. && yarn test --testPathPattern packages/react-popover"
+  },
+  "devDependencies": {
+    "flow-copy-source": "^2.0.2",
+    "microbundle": "^0.8.3",
+    "react": "^16.8.0"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0"
+  },
+  "dependencies": {
+    "@emotion/styled": "^10.0.10",
+    "@quid/merge-refs": "^1.38.1",
+    "@quid/react-mouse-outside": "^1.38.1",
+    "@quid/react-use-controlled-state": "^1.0.0",
+    "@quid/theme": "^1.38.6",
+    "color": "^3.1.0",
+    "react-popper": "^1.3.3"
+  }
+}

--- a/packages/react-popover/src/__snapshots__/index.test.js.snap
+++ b/packages/react-popover/src/__snapshots__/index.test.js.snap
@@ -1,0 +1,210 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a basic popover 1`] = `
+Array [
+  <div>
+    referece
+  </div>,
+  <div>
+    popover
+  </div>,
+]
+`;
+
+exports[`renders the Arrow component 1`] = `
+.emotion-3 {
+  display: block;
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-color: #E3E6E8;
+}
+
+.emotion-1 {
+  display: block;
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-color: #E3E6E8;
+}
+
+<Arrow
+  theme={
+    Object {
+      "backdrop": "rgba(255, 255, 255, 0.8)",
+      "background": "#FFFFFF",
+      "colors": Object {
+        "aqua": "#1ED7D1",
+        "black": "#121212",
+        "blue": "#2E56BC",
+        "brown": "#9A6051",
+        "coral": "#F04E53",
+        "emerald": "#00804F",
+        "gray1": "#E3E6E8",
+        "gray2": "#C7CCD1",
+        "gray3": "#8F9BA3",
+        "gray4": "#6C7983",
+        "gray5": "#49535A",
+        "gray6": "#2E3338",
+        "gray7": "#1B1F22",
+        "green": "#039849",
+        "highlighted": "rgba(0, 193, 187, 0.6)",
+        "lemon": "#EAE962",
+        "lilac": "#9581BC",
+        "lime": "#87C445",
+        "link": "#28beb8",
+        "margenta": "#B22264",
+        "orange": "#F9621E",
+        "peach": "#F4A467",
+        "pink": "#D72E8E",
+        "purple": "#A8499A",
+        "quidTeal": "#00a7b8",
+        "red": "#E61E27",
+        "rose": "#BF8092",
+        "selected": "#00c1bb",
+        "sky": "#A6DEF3",
+        "tan": "#C1966B",
+        "teal": "#3C8790",
+        "white": "#FFFFFF",
+        "yellow": "#FFCE03",
+      },
+      "disabled": "#8F9BA3",
+      "link": "#28beb8",
+      "primary": "#2E3338",
+      "primaryInverse": "#E3E6E8",
+      "secondary": "#6C7983",
+      "selected": "#00c1bb",
+      "shadow": "#121212",
+      "sizes": Object {
+        "large": "20px",
+        "regular": "10px",
+        "small": "5px",
+      },
+    }
+  }
+>
+  <ForwardRef
+    className="emotion-3 emotion-0"
+  >
+    <div
+      className="emotion-3 emotion-0"
+    >
+      <ArrowBorder
+        className="emotion-3 emotion-0"
+      >
+        <div
+          className="emotion-0 emotion-1 emotion-2"
+        />
+      </ArrowBorder>
+    </div>
+  </ForwardRef>
+</Arrow>
+`;
+
+exports[`renders the Container component 1`] = `
+.emotion-0 {
+  background-color: #E3E6E8;
+  color: #2E3338;
+  border: 1px solid #C7CCD1;
+  border-radius: 2px;
+  padding: 5px;
+  -webkit-filter: drop-shadow( 0 2px 2px rgba(18,18,18,0.2) );
+  filter: drop-shadow( 0 2px 2px rgba(18,18,18,0.2) );
+  z-index: 1;
+  margin-top: 6px;
+}
+
+.emotion-0 .e1oyuzn01 {
+  border-width: 6px;
+  top: -6px;
+  border-top-width: 0;
+  border-top-color: transparent;
+  border-right-color: transparent;
+  border-left-color: transparent;
+  left: 0px;
+  top: 0px;
+}
+
+.emotion-0 .e1oyuzn00 {
+  border-width: 7px;
+  border-bottom-color: #C7CCD1;
+  left: -7px;
+  top: -7px;
+  -webkit-transform: translateY( -1.5px );
+  -ms-transform: translateY( -1.5px );
+  transform: translateY( -1.5px );
+  z-index: -1;
+}
+
+<Container
+  arrowProps={
+    Object {
+      "style": Object {
+        "left": 0,
+        "top": 0,
+      },
+    }
+  }
+  arrowSize={6}
+  placement="bottom"
+  theme={
+    Object {
+      "backdrop": "rgba(255, 255, 255, 0.8)",
+      "background": "#FFFFFF",
+      "colors": Object {
+        "aqua": "#1ED7D1",
+        "black": "#121212",
+        "blue": "#2E56BC",
+        "brown": "#9A6051",
+        "coral": "#F04E53",
+        "emerald": "#00804F",
+        "gray1": "#E3E6E8",
+        "gray2": "#C7CCD1",
+        "gray3": "#8F9BA3",
+        "gray4": "#6C7983",
+        "gray5": "#49535A",
+        "gray6": "#2E3338",
+        "gray7": "#1B1F22",
+        "green": "#039849",
+        "highlighted": "rgba(0, 193, 187, 0.6)",
+        "lemon": "#EAE962",
+        "lilac": "#9581BC",
+        "lime": "#87C445",
+        "link": "#28beb8",
+        "margenta": "#B22264",
+        "orange": "#F9621E",
+        "peach": "#F4A467",
+        "pink": "#D72E8E",
+        "purple": "#A8499A",
+        "quidTeal": "#00a7b8",
+        "red": "#E61E27",
+        "rose": "#BF8092",
+        "selected": "#00c1bb",
+        "sky": "#A6DEF3",
+        "tan": "#C1966B",
+        "teal": "#3C8790",
+        "white": "#FFFFFF",
+        "yellow": "#FFCE03",
+      },
+      "disabled": "#8F9BA3",
+      "link": "#28beb8",
+      "primary": "#2E3338",
+      "primaryInverse": "#E3E6E8",
+      "secondary": "#6C7983",
+      "selected": "#00c1bb",
+      "shadow": "#121212",
+      "sizes": Object {
+        "large": "20px",
+        "regular": "10px",
+        "small": "5px",
+      },
+    }
+  }
+>
+  <div
+    className="emotion-0 emotion-1"
+  />
+</Container>
+`;

--- a/packages/react-popover/src/index.js
+++ b/packages/react-popover/src/index.js
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) Quid, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// @flow
+import * as React from 'react';
+import {
+  Manager,
+  Reference,
+  Popper,
+  type PopperArrowProps,
+} from 'react-popper';
+import { type Placement, type Modifiers } from 'popper.js';
+import styled from '@emotion/styled/macro';
+import css from '@emotion/css/macro';
+import { themes } from '@quid/theme';
+import Color from 'color';
+import MouseOutside from '@quid/react-mouse-outside';
+import mergeRefs from '@quid/merge-refs';
+import useControlledState from '@quid/react-use-controlled-state';
+
+function getOppositePlacement(placement) {
+  const hash = { left: 'right', right: 'left', bottom: 'top', top: 'bottom' };
+  return placement.replace(/left|right|bottom|top/g, matched => hash[matched]);
+}
+
+const ArrowBorder = styled.div``;
+
+const Arrow = styled(
+  React.forwardRef((props, ref) => (
+    <div {...props} ref={ref}>
+      <ArrowBorder {...props} />
+    </div>
+  ))
+)`
+  display: block;
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-color: ${props => props.theme.primaryInverse};
+`;
+Arrow.defaultProps = {
+  theme: themes.light,
+};
+
+const Container = styled.div`
+  background-color: ${props => props.theme.primaryInverse};
+  color: ${props => props.theme.primary};
+  border: 1px solid ${props => props.theme.colors.gray2};
+  border-radius: 2px;
+  padding: ${props => props.theme.sizes.small};
+  filter: drop-shadow(
+    0 2px 2px
+      ${props =>
+        Color(props.theme.colors.black)
+          .alpha(0.2)
+          .string()}
+  );
+  z-index: 1;
+
+  ${props => css`
+    margin-${getOppositePlacement(props.placement)}: ${props.arrowSize}px;
+
+    ${Arrow} {
+      border-width: ${props.arrowSize}px;
+      ${getOppositePlacement(props.placement)}: -${props.arrowSize}px;
+      border-${getOppositePlacement(props.placement)}-width: 0;
+      border-${getOppositePlacement(props.placement)}-color: transparent;
+      ${
+        ['top', 'bottom'].includes(props.placement)
+          ? css`
+              border-right-color: transparent;
+              border-left-color: transparent;
+            `
+          : css`
+              border-top-color: transparent;
+              border-bottom-color: transparent;
+            `
+      }
+
+      left: ${props.arrowProps.style.left}px;
+      top: ${props.arrowProps.style.top}px;
+    }
+
+    ${ArrowBorder} {
+      border-width: ${props.arrowSize + 1}px;
+      border-${props.placement}-color: ${props.theme.colors.gray2};
+      left: -${props.arrowSize + 1}px;
+      top: -${props.arrowSize + 1}px;
+      ${
+        ['left', 'right'].includes(props.placement)
+          ? css`
+              transform: translateX(
+                ${props.placement === 'left' ? 1.5 : -1.5}px
+              );
+            `
+          : css`
+              transform: translateY(
+                ${props.placement === 'top' ? 1.5 : -1.5}px
+              );
+            `
+      }
+
+      z-index: -1;
+    }
+  `}
+`;
+Container.defaultProps = {
+  arrowSize: 6,
+  placement: 'bottom',
+  arrowProps: { style: { top: 0, left: 0 } },
+  theme: themes.light,
+};
+
+type RenderPopoverProps = {
+  ref: React.ElementRef<any>,
+  style: $Shape<CSSStyleDeclaration>,
+  placement: Placement,
+  arrowProps: PopperArrowProps,
+  toggle: () => void,
+};
+
+type Props = {
+  open?: boolean,
+  onToggle?: boolean => void,
+  defaultOpen?: boolean,
+  renderPopover: RenderPopoverProps => React.Node,
+  placement?: Placement,
+  modifiers?: Modifiers,
+  eventsEnabled?: boolean,
+  positionFixed?: boolean,
+  children: ({ ref: React.ElementRef<any>, toggle: () => void }) => React.Node,
+};
+
+const Popover = ({
+  defaultOpen,
+  open,
+  onToggle,
+  renderPopover,
+  placement = 'bottom',
+  modifiers,
+  eventsEnabled = true,
+  positionFixed = false,
+  children,
+}: Props) => {
+  const [isOpen, setOpen] = useControlledState(defaultOpen, open, onToggle);
+  const toggle = React.useCallback(() => setOpen(open => !open), [setOpen]);
+  const close = React.useCallback(() => setOpen(false), [setOpen]);
+  const referenceRef = React.useRef();
+  const popperRef = React.useRef();
+
+  return (
+    <MouseOutside refs={[referenceRef, popperRef]} onClickOutside={close}>
+      {() => (
+        <Manager>
+          <Reference>
+            {({ ref }) =>
+              children({ ref: mergeRefs(ref, referenceRef), toggle })
+            }
+          </Reference>
+          {isOpen && (
+            <Popper
+              placement={placement}
+              modifiers={modifiers}
+              eventsEnabled={eventsEnabled}
+              positionFixed={positionFixed}
+            >
+              {({ ref, ...popperProps }) =>
+                renderPopover({
+                  ...popperProps,
+                  ref: mergeRefs(ref, popperRef),
+                  toggle,
+                })
+              }
+            </Popper>
+          )}
+        </Manager>
+      )}
+    </MouseOutside>
+  );
+};
+
+export { Container, Arrow };
+
+export default Popover;

--- a/packages/react-popover/src/index.md
+++ b/packages/react-popover/src/index.md
@@ -1,0 +1,73 @@
+**RenderPopoverProps** type definition:
+
+| Prop name    | Type                            | Default | Description |
+| ------------ | ------------------------------- | ------- | ----------- |
+| `ref`        | `React.ElementRef<any>`         |         |             |
+| `style`      | `$Shape<CSSStyleDeclaration>`   |         |             |
+| `placement`  | `Popper.js#Placement`           |         |             |
+| `arrowProps` | `react-popper#PopperArrowProps` |         |             |
+| `toggle`     | `() => void`                    |         |             |
+
+### Uncontrolled component
+
+The most basic usage example of the Popover component can be achieved by
+providing as `Popover` `children` a render-prop function providing a
+`ref` and `toggle` properties, and a `renderPopover` property, providing
+a set of properties described in the table above.
+
+In this case, the component state will be handled internally by the
+component itself, you may decide to provide an `onToggle` property to
+read the value when it changes, but you are not allowed define the current
+state in a declarative way.
+
+```jsx
+import { Button } from '@quid/react-core';
+import Popover, { Container, Arrow } from '.'; // @quid/react-popover
+
+<Popover
+  renderPopover={props => (
+    <Container {...props}>
+      Popover content
+      <Arrow ref={props.arrowProps.ref} />
+    </Container>
+  )}
+>
+  {({ ref, toggle }) => (
+    <Button type="button" onClick={toggle} ref={ref}>
+      Reference element
+    </Button>
+  )}
+</Popover>;
+```
+
+### Controlled component
+
+If you'd rather control the component state declaratively, you can provide
+an `open` property, which can be set to either `true` or `false`, and an
+`onToggle` property, you will need to use to update the `open` property when
+a state change is triggered.
+
+```jsx
+import { Button } from '@quid/react-core';
+import Popover, { Container, Arrow } from '.'; // @quid/react-popover
+
+initialState = { open: false };
+
+<Popover
+  open={state.open}
+  onToggle={open => setState({ open })}
+  placement="right"
+  renderPopover={props => (
+    <Container {...props}>
+      Popover content
+      <Arrow ref={props.arrowProps.ref} />
+    </Container>
+  )}
+>
+  {({ ref, toggle }) => (
+    <Button type="button" onClick={toggle} ref={ref}>
+      Reference element
+    </Button>
+  )}
+</Popover>;
+```

--- a/packages/react-popover/src/index.test.js
+++ b/packages/react-popover/src/index.test.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Quid, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// @flow
+import * as React from 'react';
+// $FlowFixMe: need to upgrade Flow
+import { act } from 'react-dom/test-utils';
+import { mount } from 'enzyme';
+import Popover, { Container, Arrow } from '.';
+
+it('renders a basic popover', () => {
+  expect(
+    mount(
+      <Popover
+        open
+        onToggle={jest.fn()}
+        renderPopover={({ ref }) => <div ref={ref}>popover</div>}
+      >
+        {({ ref }) => <div ref={ref}>referece</div>}
+      </Popover>
+    )
+  ).toMatchSnapshot();
+});
+
+it('renders the Container component', () => {
+  expect(mount(<Container placement="bottom" />)).toMatchSnapshot();
+});
+
+it('renders the Container component on different placements', () => {
+  expect(mount(<Container placement="bottom" />)).toHaveStyleRule(
+    'border-right-color',
+    'transparent',
+    { target: `${Arrow}` }
+  );
+  expect(mount(<Container placement="top" />)).toHaveStyleRule(
+    'border-right-color',
+    'transparent',
+    { target: `${Arrow}` }
+  );
+  expect(mount(<Container placement="right" />)).toHaveStyleRule(
+    'border-top-color',
+    'transparent',
+    { target: `${Arrow}` }
+  );
+  expect(mount(<Container placement="left" />)).toHaveStyleRule(
+    'border-top-color',
+    'transparent',
+    { target: `${Arrow}` }
+  );
+});
+
+it('renders the Arrow component', () => {
+  expect(mount(<Arrow />)).toMatchSnapshot();
+});
+
+it('can be toggled programmatically', () => {
+  const handleToggle = jest.fn();
+  const wrapper = mount(
+    <Popover
+      open
+      onToggle={handleToggle}
+      renderPopover={({ ref, toggle }) => (
+        <x-popover ref={ref} onClick={toggle}>
+          popover
+        </x-popover>
+      )}
+    >
+      {({ ref }) => <div ref={ref}>referece</div>}
+    </Popover>
+  );
+
+  wrapper.find('x-popover').simulate('click');
+
+  expect(handleToggle).toHaveBeenCalledWith(false);
+
+  act(() => void document.dispatchEvent(new Event('click')));
+
+  expect(handleToggle).toHaveBeenCalledWith(false);
+  expect(handleToggle).toHaveBeenCalledTimes(2);
+});

--- a/packages/react-use-controlled-state/README.md
+++ b/packages/react-use-controlled-state/README.md
@@ -1,0 +1,93 @@
+`@quid/react-use-controlled-state` is a custom React Hook designed to
+enable developers to easily create components able to work both as
+[fully controlled][controlled-components] or [fully uncontrolled][uncontrolled-components]
+without code repetition.
+
+## Installation
+
+```bash
+npm install --save @quid/react-use-controlled-state
+
+# or
+
+yarn add @quid/react-use-controlled-state
+```
+
+## Usage example
+
+Take this component as example:
+
+```jsx static
+import useControlledState from '@quid/react-use-controlled-state';
+
+const MyComponent = ({ defaultOpen, open, onChange }) => {
+  const [state, setState] = useControlledState(defaultOpen, open, onChange);
+
+  return (
+    <button type="button" onClick={() => setState(current => !current)}>
+      {state === true ? 'component is open' : 'component is closed'}
+    </button>
+  );
+};
+```
+
+Thanks to `@quid/react-use-controlled-state`, this component can be used in two
+different ways now.
+
+The first way let's you define a default open state, and let the component hold
+and handle the state changes for you, transparently.
+
+```jsx
+import useControlledState from '@quid/react-use-controlled-state';
+
+const MyComponent = ({ defaultOpen, open, onChange }) => {
+  const [state, setState] = useControlledState(defaultOpen, open, onChange);
+
+  return (
+    <button type="button" onClick={() => setState(current => !current)}>
+      {state === true ? 'component is open' : 'component is closed'}
+    </button>
+  );
+};
+
+<MyComponent defaultOpen={false} />;
+```
+
+The second way, makes you define a `open` property, along with an `onChange` callback.  
+You will be responsible to update the state and maintain it externally.
+
+```jsx
+import useControlledState from '@quid/react-use-controlled-state';
+
+const MyComponent = ({ defaultOpen, open, onChange }) => {
+  const [state, setState] = useControlledState(defaultOpen, open, onChange);
+
+  return (
+    <button type="button" onClick={() => setState(current => !current)}>
+      {state === true ? 'component is open' : 'component is closed'}
+    </button>
+  );
+};
+
+const App = () => {
+  const [isOpen, setOpen] = React.useState(false);
+
+  return <MyComponent open={isOpen} onChange={open => setOpen(open)} />;
+};
+
+<App />;
+```
+
+Both the approaches have their upsides and downsides, and it's useful to let your
+users decide what fits better their needs.
+
+<!-- NPM_ONLY> -->
+
+---
+
+More documentation is available at https://ui.quid.com
+
+<!-- <NPM_ONLY -->
+
+[controlled-components]: https://reactjs.org/docs/forms.html#controlled-components
+[uncontrolled-components]: https://reactjs.org/docs/uncontrolled-components.html

--- a/packages/react-use-controlled-state/package.json
+++ b/packages/react-use-controlled-state/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@quid/react-use-controlled-state",
+  "version": "1.0.0",
+  "description": "React Hook to easily create fully controlled/uncontrolled React components.",
+  "main": "dist/index.js",
+  "main:umd": "dist/index.umd.js",
+  "module": "dist/index.es.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/quid/refraction/tree/master/packages/react-use-controlled-state"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "start": "microbundle watch",
+    "prepare": "microbundle build --jsx React.createElement && flow-copy-source --ignore '{__mocks__/*,*.test}.js' src dist",
+    "test": "cd ../.. && yarn test --testPathPattern packages/react-use-controlled-state"
+  },
+  "devDependencies": {
+    "flow-copy-source": "^2.0.2",
+    "microbundle": "^0.8.3",
+    "react": "^16.8.0"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0"
+  }
+}

--- a/packages/react-use-controlled-state/src/index.js
+++ b/packages/react-use-controlled-state/src/index.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Quid, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// @flow
+import * as React from 'react';
+
+declare function useControlledState<T>( // eslint-disable-line no-redeclare
+  ?T,
+  ?T,
+  ?(T) => void
+): [T, ((T => T) | T) => void];
+
+// Easily switch between fully controlled to fully uncontrolled component
+// if only controlledValue and controlValue are defined, act as fully controlled
+// if only defaultValue is defined (and, optionally, controlValue is defined), act as fully uncontrolled
+// eslint-disable-next-line no-redeclare
+function useControlledState(defaultValue, controlledValue, controlValue) {
+  const [internalState, setInternalState] = React.useState(defaultValue);
+
+  const isControlled = (controlledValue, defaultValue): boolean %checks =>
+    controlledValue !== undefined && defaultValue === undefined;
+
+  if (controlledValue !== undefined && defaultValue !== undefined) {
+    console.error(
+      'Warning: both `controlledValue` and `defaultValue` have been defined, decide wheter if you desire the component to be controlled or uncontrolled defining only one of the two properties.'
+    );
+  }
+
+  if (controlledValue !== undefined && controlValue == null) {
+    console.error(
+      'Warning: a `controlledValue` was provided, but a `controlValue` is missing. To update the state of the Hook you will need to define one.'
+    );
+  }
+
+  const setState = React.useCallback(
+    value => {
+      typeof controlValue === 'function' &&
+        controlValue(
+          typeof value === 'function' ? value(controlledValue) : value
+        );
+
+      setInternalState(value);
+    },
+    [controlledValue, controlValue, defaultValue]
+  );
+
+  const state = isControlled(controlledValue, defaultValue)
+    ? controlledValue
+    : internalState;
+
+  return [state, setState];
+}
+
+export default useControlledState;

--- a/packages/react-use-controlled-state/src/index.test.js
+++ b/packages/react-use-controlled-state/src/index.test.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) Quid, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// @flow
+import * as React from 'react';
+import { mount } from 'enzyme';
+import useControlledState from '.';
+
+const UseControlledState = ({
+  children,
+  defaultValue,
+  controlledValue,
+  controlValue,
+}: {
+  children: ([boolean, ((boolean => boolean) | boolean) => void]) => React.Node,
+  defaultValue?: boolean,
+  controlledValue?: boolean,
+  controlValue?: boolean => void,
+}) => children(useControlledState(defaultValue, controlledValue, controlValue));
+
+it('works as uncontrolled', () => {
+  const wrapper = mount(
+    <UseControlledState defaultValue={true}>
+      {([state]) => <div data-state={state} />}
+    </UseControlledState>
+  );
+
+  expect(wrapper.find('div').prop('data-state')).toBe(true);
+});
+
+it('works as controlled - setState(fn)', () => {
+  const Test = props => {
+    const [value, setValue] = React.useState(props.controlledValue);
+    return (
+      <UseControlledState
+        controlValue={value => setValue(value)}
+        controlledValue={value}
+      >
+        {props.children}
+      </UseControlledState>
+    );
+  };
+  const wrapper = mount(
+    <Test controlledValue={true}>
+      {([state, setState]) => (
+        <div data-state={state} onClick={() => setState(bool => !bool)} />
+      )}
+    </Test>
+  );
+
+  expect(wrapper.find('div').prop('data-state')).toBe(true);
+
+  wrapper.find('div').simulate('click');
+
+  expect(wrapper.find('div').prop('data-state')).toBe(false);
+});
+
+it('works as controlled - setState(value)', () => {
+  const Test = props => {
+    const [value, setValue] = React.useState(props.controlledValue);
+    return (
+      <UseControlledState
+        controlValue={value => setValue(value)}
+        controlledValue={value}
+      >
+        {props.children}
+      </UseControlledState>
+    );
+  };
+  const wrapper = mount(
+    <Test controlledValue={true}>
+      {([state, setState]) => (
+        <div data-state={state} onClick={() => setState(!state)} />
+      )}
+    </Test>
+  );
+
+  expect(wrapper.find('div').prop('data-state')).toBe(true);
+
+  wrapper.find('div').simulate('click');
+
+  expect(wrapper.find('div').prop('data-state')).toBe(false);
+});
+
+it('warns on wrong usage', () => {
+  // $FlowIgnoreMe: I know Flow, I know, it's fine
+  console.error = jest.fn();
+  mount(
+    <UseControlledState defaultValue={true} controlledValue={true}>
+      {([state]) => <div data-state={state} />}
+    </UseControlledState>
+  );
+
+  expect(console.error).toHaveBeenCalled();
+});
+
+it('warns on wrong usage', () => {
+  // $FlowIgnoreMe: I know Flow, I know, it's fine
+  console.error = jest.fn();
+  mount(
+    <UseControlledState controlledValue={true}>
+      {([state]) => <div data-state={state} />}
+    </UseControlledState>
+  );
+
+  expect(console.error).toHaveBeenCalled();
+});

--- a/packages/theme/src/themes/dark.js
+++ b/packages/theme/src/themes/dark.js
@@ -7,6 +7,7 @@
 // @flow
 import Color from 'color';
 import colors from '../colors';
+import sizes from '../sizes';
 
 const darkTheme = {
   primary: colors.gray1,
@@ -20,6 +21,8 @@ const darkTheme = {
   link: colors.link,
   disabled: colors.gray3,
   shadow: colors.black,
+  colors,
+  sizes,
 };
 
 export default darkTheme;

--- a/packages/theme/src/themes/light.js
+++ b/packages/theme/src/themes/light.js
@@ -7,6 +7,7 @@
 // @flow
 import Color from 'color';
 import colors from '../colors';
+import sizes from '../sizes';
 
 const lightTheme = {
   primary: colors.gray6,
@@ -20,6 +21,8 @@ const lightTheme = {
   link: colors.link,
   disabled: colors.gray3,
   shadow: colors.black,
+  colors,
+  sizes,
 };
 
 export default lightTheme;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1104,7 +1104,29 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.1.tgz#e93c13942592cf5ef01aa8297444dc192beee52f"
   integrity sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==
 
-"@emotion/serialize@^0.11.2", "@emotion/serialize@^0.11.6":
+"@emotion/serialize@^0.11.2":
+  version "0.11.2"
+  resolved "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.2.tgz#f6cdf7b20ade02251525add0e50f8a56d47e4a3f"
+  integrity sha512-6bWsiynUj+KByNXpcSbx/2xj9OI7Vty/IeIvB5ArPswosyp0N0GezDqQ50IjFDfDUPv0LNCtyyKuTtlFy62Epw==
+  dependencies:
+    "@emotion/hash" "0.7.1"
+    "@emotion/memoize" "0.7.1"
+    "@emotion/unitless" "0.7.3"
+    "@emotion/utils" "0.11.1"
+    csstype "^2.5.7"
+
+"@emotion/serialize@^0.11.3":
+  version "0.11.3"
+  resolved "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.3.tgz#c4af2d96e3ddb9a749b7b567daa7556bcae45af2"
+  integrity sha512-6Q+XH/7kMdHwtylwZvdkOVMydaGZ989axQ56NF7urTR7eiDMLGun//pFUy31ha6QR4C6JB+KJVhZ3AEAJm9Z1g==
+  dependencies:
+    "@emotion/hash" "0.7.1"
+    "@emotion/memoize" "0.7.1"
+    "@emotion/unitless" "0.7.3"
+    "@emotion/utils" "0.11.1"
+    csstype "^2.5.7"
+
+"@emotion/serialize@^0.11.6":
   version "0.11.6"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.6.tgz#78be8b9ee9ff49e0196233ba6ec1c1768ba1e1fc"
   integrity sha512-n4zVv2qGLmspF99jaEUwnMV0fnEGsyUMsC/8KZKUSUTZMYljHE+j+B6rSD8PIFtaUIhHaxCG2JawN6L+OgLN0Q==
@@ -1130,7 +1152,7 @@
     "@emotion/utils" "0.11.1"
     object-assign "^4.1.1"
 
-"@emotion/styled-base@^10.0.10", "@emotion/styled-base@^10.0.4":
+"@emotion/styled-base@^10.0.10", "@emotion/styled-base@^10.0.4", "@emotion/styled-base@^10.0.5", "@emotion/styled-base@^10.0.7":
   version "10.0.10"
   resolved "https://registry.yarnpkg.com/@emotion/styled-base/-/styled-base-10.0.10.tgz#ffb811295c9dcd9b3c12bf93301d7d8bcb02e6f4"
   integrity sha512-uZwKrBfcH7jCRAQi5ZxsEGIZ+1Zr9/lof4TMsIolC0LSwpnWkQ+JRJLy+p4ZyATee9SdmyCV0sG/VTngVSnrpA==
@@ -1140,13 +1162,29 @@
     "@emotion/utils" "0.11.1"
     object-assign "^4.1.1"
 
-"@emotion/styled@^10.0.2", "@emotion/styled@^10.0.4", "@emotion/styled@^10.0.6", "@emotion/styled@^10.0.7":
+"@emotion/styled@^10.0.2", "@emotion/styled@^10.0.4":
   version "10.0.10"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-10.0.10.tgz#ec241a9389a585b2c2638b709c262c28469ed92e"
   integrity sha512-k4p5WxwYJUVYKBlwOmfpqxeSwdPHqUycLHJY9ftleEvMfphYLB8lt9oPEkEty5XH4URh/wyUfZ2wW2ojrHODWA==
   dependencies:
     "@emotion/styled-base" "^10.0.10"
     babel-plugin-emotion "^10.0.9"
+
+"@emotion/styled@^10.0.6":
+  version "10.0.6"
+  resolved "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.6.tgz#e6591cf7b0fd56e82a0ae7e421568229e7c6d5f9"
+  integrity sha512-tJqeGmNueLcdVqQKsaXJq8fGsYg5O8E6GFxNCALHhS+BKl8kXZKn1fnPnz2iNTHuXGsxolt4uzAuj0UD/MF4NQ==
+  dependencies:
+    "@emotion/styled-base" "^10.0.5"
+    babel-plugin-emotion "^10.0.6"
+
+"@emotion/styled@^10.0.7":
+  version "10.0.7"
+  resolved "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.7.tgz#e36c84bf14435127481a1ea0b038d64a15c13995"
+  integrity sha512-H/7wi2bFYl6GdxBPYef0FNYay1ay5iKFGYxmkuH8WJZnDc/bf1Bx+lH9IQ+QujAMgmAtUHwJsgO2vwj0LEIYcg==
+  dependencies:
+    "@emotion/styled-base" "^10.0.7"
+    babel-plugin-emotion "^10.0.7"
 
 "@emotion/stylis@0.8.3":
   version "0.8.3"
@@ -2788,7 +2826,23 @@ babel-plugin-dynamic-import-node@2.2.0:
   dependencies:
     object.assign "^4.1.0"
 
-babel-plugin-emotion@^10.0.9:
+babel-plugin-emotion@^10.0.6:
+  version "10.0.6"
+  resolved "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.6.tgz#fd9bb4a5dc6cf2289b656215dbbc80469fd251b3"
+  integrity sha512-JD2st8enZJn8h7W1s8kcb40r3RBCJwV9E8ZAhyyhELUMP8OYwyI9K1rz7MxRi0CoorX15kVo2NXZ+OJ6CeMY8A==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/hash" "0.7.1"
+    "@emotion/memoize" "0.7.1"
+    "@emotion/serialize" "^0.11.3"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^1.0.5"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+
+babel-plugin-emotion@^10.0.7, babel-plugin-emotion@^10.0.9:
   version "10.0.9"
   resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.9.tgz#04a0404d5a4084d5296357a393d344c0f8303ae4"
   integrity sha512-IfWP12e9/wHtWHxVTzD692Nbcmrmcz2tip7acp6YUqtrP7slAyr5B+69hyZ8jd55GsyNSZwryNnmuDEVe0j+7w==
@@ -12555,7 +12609,7 @@ react-test-renderer@^16.0.0-0:
     react-is "^16.8.6"
     scheduler "^0.13.6"
 
-react@^16.0.0, react@^16.3.0, react@^16.7.0:
+react@^16.0.0, react@^16.3.0, react@^16.7.0, react@^16.8.0:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
   integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

This PR introduces two new packages:

- `@quid/react-use-controlled-state`
- `@quid/react-popover`

It also fixes an issue inside `@quid/theme`and a `ref` issue with Button.

![image](https://user-images.githubusercontent.com/5382443/55971270-6960d100-5c81-11e9-93d0-4c365c6e9471.png)


## Affected packages

<!-- List below all the affected packages -->

- @quid/react-use-controlled-state
- @quid/react-popover
- @quid/theme
- @quid/react-core


Internal ticket number: AF-597