### PR TITLE
fix: workaround for missing icons

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -27,7 +27,7 @@ const packages = fs
 
 module.exports = {
   webpackConfig: override(
-    require('react-scripts/config/webpack.config')(process.env.NODE_ENV)
+    require('react-scripts/config/webpack.config')('development')
   ),
   ignore: ['**/*.{test,spec}.js', '**/dist/**/*'],
   skipComponentsWithoutExample: true,


### PR DESCRIPTION

<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

<!-- Describe what your PR changes -->

Something broken in the upgrade of styleguidist and CRA, building the app with the development config fixes the issue, it’s not optimal but it’s a viable workaround to fix the issue until I find a better solution.

<!-- List below all the affected packages -->

