### PR TITLE
fix: restore PR #73, accidentally reverted by 9f0c810

### DIFF
--- a/packages/react-core/src/Button/__snapshots__/index.test.js.snap
+++ b/packages/react-core/src/Button/__snapshots__/index.test.js.snap
@@ -82,7 +82,11 @@ exports[`renders a Button with small size 1`] = `
       className="emotion-0 emotion-1"
       type="button"
     >
-      Hello, World!
+      <span
+        key=".0"
+      >
+        Hello, World!
+      </span>
     </button>
   </ForwardRef>
 </Button>
@@ -184,7 +188,11 @@ exports[`renders a disabled and transparent Button 1`] = `
       disabled={true}
       type="button"
     >
-      Hello, World!
+      <span
+        key=".0"
+      >
+        Hello, World!
+      </span>
     </button>
   </ForwardRef>
 </Button>
@@ -275,7 +283,11 @@ exports[`renders the expected markup 1`] = `
       data-action="foo"
       type="button"
     >
-      Hello, World!
+      <span
+        key=".0"
+      >
+        Hello, World!
+      </span>
     </button>
   </ForwardRef>
 </Button>

--- a/packages/react-core/src/Button/index.js
+++ b/packages/react-core/src/Button/index.js
@@ -82,6 +82,7 @@ const Button = styled(
         importance,
         disabled,
         type,
+        children,
         ...props
       }: Props,
       ref: React.ElementRef<any>
@@ -98,7 +99,17 @@ const Button = styled(
         specificProps = { disabled, type };
       }
 
-      return <Tag {...specificProps} {...props} ref={ref} />;
+      return (
+        <Tag {...specificProps} {...props}>
+          {React.Children.map(children, node =>
+            ['string', 'number'].includes(typeof node) ? (
+              <span>{node}</span>
+            ) : (
+              node
+            )
+          )}
+        </Tag>
+      );
     }
   )
 )`


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

<!-- Describe what your PR changes -->
restore PR #73, accidentally reverted by 9f0c810

![image](https://user-images.githubusercontent.com/5382443/56378072-2fa54280-620c-11e9-9795-dbb73eae76de.png)


## Affected packages

<!-- List below all the affected packages -->

- @quid/react-core

