### PR TITLE
fix: forward Button “ref” property

### DIFF
--- a/packages/react-core/src/Button/index.js
+++ b/packages/react-core/src/Button/index.js
@@ -100,7 +100,7 @@ const Button = styled(
       }
 
       return (
-        <Tag {...specificProps} {...props}>
+        <Tag {...specificProps} {...props} ref={ref}>
           {React.Children.map(children, node =>
             ['string', 'number'].includes(typeof node) ? (
               <span>{node}</span>

--- a/packages/react-core/src/Button/index.test.js
+++ b/packages/react-core/src/Button/index.test.js
@@ -113,6 +113,12 @@ it('renders a Button with type=submit', () => {
   expect(wrapper.find('button').props().type).toBe('submit');
 });
 
+it('forwards ref properly', () => {
+  const ref = React.createRef();
+  mount(<Button ref={ref}>Foobar</Button>);
+  expect(ref.current).toBeDefined();
+});
+
 // it('renders properly with isGroupChild property', () => {
 //   const wrapper = mount(<Button isGroupChild />);
 //   expect(wrapper).toMatchSnapshot();


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [ ] I updated the documentation and examples accordingly; N/A

## Changes description

Fixes the `ref` property on `Button`

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-core

