### PR TITLE
feat: Tooltip component

### DIFF
--- a/packages/react-popover/README.md
+++ b/packages/react-popover/README.md
@@ -3,8 +3,8 @@ used to quickly create popovers in your applications.
 
 It supports all the advanced positioning provided by `react-popper`,
 a "click outside" detection system to automatically close the popover
-whenever the user clicks outside of it, and a render-props based API
-to allow full customization of the component rendering.
+whenever the user clicks outside of it, open and close delays, and a
+render-props based API to allow full customization of the component rendering.
 
 As convenience utility, a `Container` component is exported from the paclage
 

--- a/packages/react-popover/package.json
+++ b/packages/react-popover/package.json
@@ -33,6 +33,7 @@
     "@quid/react-use-controlled-state": "^2.0.0",
     "@quid/theme": "^2.1.2",
     "color": "^3.1.0",
-    "react-popper": "^1.3.3"
+    "react-popper": "^1.3.3",
+    "use-debounce": "^2.1.0"
   }
 }

--- a/packages/react-popover/src/index.md
+++ b/packages/react-popover/src/index.md
@@ -32,7 +32,7 @@ import Popover, { Container, Arrow } from '.'; // @quid/react-popover
     </Container>
   )}
 >
-  {({ ref, toggle }) => (
+  {({ ref, toggle, onMouseEnter }) => (
     <Button type="button" onClick={toggle} ref={ref}>
       Reference element
     </Button>

--- a/packages/react-popover/src/index.test.js
+++ b/packages/react-popover/src/index.test.js
@@ -6,10 +6,13 @@
  */
 // @flow
 import * as React from 'react';
-// $FlowFixMe: need to upgrade Flow
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import Popover, { Container, Arrow } from '.';
+
+jest.mock('use-debounce', () => ({
+  useDebouncedCallback: callback => [callback, jest.fn()],
+}));
 
 it('renders a basic popover', () => {
   expect(
@@ -56,7 +59,67 @@ it('renders the Arrow component', () => {
   expect(mount(<Arrow />)).toMatchSnapshot();
 });
 
-it('can be toggled programmatically', () => {
+it('can be open programmatically', async () => {
+  const handleToggle = jest.fn();
+  const wrapper = mount(
+    <Popover
+      onToggle={handleToggle}
+      renderPopover={({ ref }) => <x-popover ref={ref}>popover</x-popover>}
+    >
+      {({ ref, open }) => (
+        <x-reference onClick={open} ref={ref}>
+          referece
+        </x-reference>
+      )}
+    </Popover>
+  );
+
+  wrapper.find('x-reference').simulate('click');
+  act(() => void expect(handleToggle).toHaveBeenCalledWith(true));
+});
+
+it('can close on mouse move outside', async () => {
+  const handleToggle = jest.fn();
+  mount(
+    <Popover
+      open
+      onToggle={handleToggle}
+      renderPopover={({ ref }) => <x-popover ref={ref}>popover</x-popover>}
+      mouseMoveBehavior
+    >
+      {({ ref, open }) => (
+        <x-reference onClick={open} ref={ref}>
+          referece
+        </x-reference>
+      )}
+    </Popover>
+  );
+
+  act(() => void document.dispatchEvent(new Event('mousemove')));
+  expect(handleToggle).toHaveBeenCalledWith(false);
+});
+
+it('can be toggled programmatically (open)', async () => {
+  const handleToggle = jest.fn();
+  const wrapper = mount(
+    <Popover
+      onToggle={handleToggle}
+      renderPopover={({ ref }) => <x-popover ref={ref}>popover</x-popover>}
+    >
+      {({ ref, toggle }) => (
+        <x-reference onClick={toggle} ref={ref}>
+          referece
+        </x-reference>
+      )}
+    </Popover>
+  );
+
+  wrapper.find('x-reference').simulate('click');
+  act(() => void expect(handleToggle).toHaveBeenCalledWith(true));
+  handleToggle.mockClear();
+});
+
+it('can be toggled programmatically (close)', async () => {
   const handleToggle = jest.fn();
   const wrapper = mount(
     <Popover
@@ -73,11 +136,9 @@ it('can be toggled programmatically', () => {
   );
 
   wrapper.find('x-popover').simulate('click');
-
-  expect(handleToggle).toHaveBeenCalledWith(false);
+  act(() => void expect(handleToggle).toHaveBeenCalledWith(false));
+  handleToggle.mockClear();
 
   act(() => void document.dispatchEvent(new Event('click')));
-
   expect(handleToggle).toHaveBeenCalledWith(false);
-  expect(handleToggle).toHaveBeenCalledTimes(2);
 });

--- a/packages/react-tooltip/README.md
+++ b/packages/react-tooltip/README.md
@@ -1,0 +1,29 @@
+`@quid/react-tooltip` is based on `@quid/react-popover`, it's a quick
+way to add tooltips to your application without boilerplate.
+
+Think about it as a pre-configured `@quid/react-popover`.
+
+Please refer to the [`@quid/react-popover`](https://ui.quid.com/#!/Popover)
+documentation for more information.
+
+## Installation
+
+```bash
+npm install --save @quid/react-popover
+
+# or
+
+yarn add @quid/react-popover
+```
+
+<!--
+Preserve the text below to show the documentation URL on the npm page.
+You can use the "NPM_ONLY> ... <NPM_ONLY" delimiter to hide any text
+from the ui.quid.com documentation but keep it visible on the npm page.
+-->
+
+<!-- NPM_ONLY> -->
+
+More documentation is available at https://ui.quid.com
+
+<!-- <NPM_ONLY -->

--- a/packages/react-tooltip/package.json
+++ b/packages/react-tooltip/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@quid/react-tooltip",
+  "version": "1.0.0",
+  "description": "Tooltip component based on react-popper",
+  "main": "dist/index.js",
+  "main:umd": "dist/index.umd.js",
+  "module": "dist/index.es.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/quid/refraction/tree/master/packages/react-tooltip"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "start": "microbundle watch",
+    "prepare": "microbundle build --jsx React.createElement && flow-copy-source --ignore '{__mocks__/*,*.test}.js' src dist",
+    "test": "cd ../.. && yarn test --testPathPattern packages/react-tooltip"
+  },
+  "devDependencies": {
+    "flow-copy-source": "^2.0.2",
+    "microbundle": "^0.8.3",
+    "react": "^16.0.0"
+  },
+  "peerDependencies": {
+    "react": "15||16"
+  },
+  "dependencies": {
+    "@emotion/styled": "^10.0.11",
+    "@quid/react-popover": "^2.1.2"
+  }
+}

--- a/packages/react-tooltip/src/__snapshots__/index.test.js.snap
+++ b/packages/react-tooltip/src/__snapshots__/index.test.js.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders the Container component 1`] = `
+<Container
+  arrowProps={
+    Object {
+      "ref": Object {
+        "current": <x-popover-arrow />,
+      },
+      "style": Object {
+        "left": 0,
+        "top": 0,
+      },
+    }
+  }
+>
+  <ForwardRef
+    arrowProps={
+      Object {
+        "ref": Object {
+          "current": <x-popover-arrow />,
+        },
+        "style": Object {
+          "left": 0,
+          "top": 0,
+        },
+      }
+    }
+    className="css-yfonvn-Container emotion-0"
+  >
+    <x-popover-container
+      arrowProps={
+        Object {
+          "ref": Object {
+            "current": <x-popover-arrow />,
+          },
+          "style": Object {
+            "left": 0,
+            "top": 0,
+          },
+        }
+      }
+      className="css-yfonvn-Container emotion-0"
+    >
+      foobar
+      <x-popover-arrow />
+    </x-popover-container>
+  </ForwardRef>
+</Container>
+`;

--- a/packages/react-tooltip/src/index.js
+++ b/packages/react-tooltip/src/index.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Quid, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// @flow
+import * as React from 'react';
+import { type Placement, type Modifiers } from 'popper.js';
+import { type PopperArrowProps } from 'react-popper';
+import styled from '@emotion/styled/macro';
+import Popover, {
+  Container as PopoverContainer,
+  Arrow,
+} from '@quid/react-popover';
+
+type RenderTooltipProps = {
+  ref: React.ElementRef<any>,
+  style: $Shape<CSSStyleDeclaration>,
+  placement: Placement,
+  arrowProps: PopperArrowProps,
+  toggle: () => void,
+};
+
+type Props = {
+  open?: boolean,
+  onToggle?: boolean => void,
+  defaultOpen?: boolean,
+  renderTooltip: RenderTooltipProps => React.Node,
+  placement?: Placement,
+  modifiers?: Modifiers,
+  eventsEnabled?: boolean,
+  positionFixed?: boolean,
+  children: ({ ref: React.ElementRef<any>, toggle: () => void }) => React.Node,
+};
+
+const Tooltip = ({ renderTooltip, ...props }: Props) => (
+  <Popover renderPopover={renderTooltip} mouseMoveBehavior {...props} />
+);
+Tooltip.defaultProps = {
+  closeOnMouseOutside: true,
+};
+
+export const Container = styled(
+  React.forwardRef(({ arrowProps, children, ...props }, ref) => (
+    <PopoverContainer {...props} arrowProps={arrowProps} ref={ref}>
+      {children}
+      <Arrow ref={arrowProps.ref} />
+    </PopoverContainer>
+  ))
+)``;
+
+export default Tooltip;

--- a/packages/react-tooltip/src/index.md
+++ b/packages/react-tooltip/src/index.md
@@ -1,0 +1,64 @@
+**RenderTooltipProps** type definition:
+
+| Prop name   | Type                          | Default | Description |
+| ----------- | ----------------------------- | ------- | ----------- |
+| `ref`       | `React.ElementRef<any>`       |         |             |
+| `style`     | `$Shape<CSSStyleDeclaration>` |         |             |
+| `placement` | `Popper.js#Placement`         |         |             |
+| `toggle`    | `() => void`                  |         |             |
+
+### Uncontrolled component
+
+The most basic usage example of the Tooltip component can be achieved by
+providing as `Tooltip` `children` a render-prop function providing a
+`ref` and `toggle` properties, and a `renderTooltip` property, providing
+a set of properties described in the table above.
+
+In this case, the component state will be handled internally by the
+component itself, you may decide to provide an `onToggle` property to
+read the value when it changes, but you are not allowed define the current
+state in a declarative way.
+
+```jsx
+import { Button } from '@quid/react-core';
+import Tooltip, { Container } from '.'; // @quid/react-tooltip
+
+<Tooltip
+  renderTooltip={props => <Container {...props}>Tooltip content</Container>}
+>
+  {({ ref, toggle, open }) => (
+    <Button type="button" onClick={toggle} onMouseEnter={open} ref={ref}>
+      Reference element
+    </Button>
+  )}
+</Tooltip>;
+```
+
+### Controlled component
+
+If you'd rather control the component state declaratively, you can provide
+an `open` property, which can be set to either `true` or `false`, and an
+`onToggle` property, you will need to use to update the `open` property when
+a state change is triggered.
+
+```jsx
+import { Button } from '@quid/react-core';
+import Tooltip, { Container } from '.'; // @quid/react-tooltip
+
+initialState = { open: false };
+
+<Tooltip
+  open={state.open}
+  onToggle={open => setState({ open })}
+  placement="right"
+  renderTooltip={props => <Container {...props}>Tooltip content</Container>}
+  openDelay={300}
+  closeDelay={500}
+>
+  {({ ref, toggle, open }) => (
+    <Button type="button" onClick={toggle} onMouseEnter={open} ref={ref}>
+      Reference element
+    </Button>
+  )}
+</Tooltip>;
+```

--- a/packages/react-tooltip/src/index.test.js
+++ b/packages/react-tooltip/src/index.test.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Quid, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// @flow
+import * as React from 'react';
+import { act } from 'react-dom/test-utils';
+import { mount } from 'enzyme';
+import Tooltip, { Container } from '.';
+
+jest.mock('@quid/react-popover', () => ({
+  __esModule: true,
+  default: ({ children, ...props }) => children(props),
+  Container: 'x-popover-container',
+  Arrow: 'x-popover-arrow',
+}));
+
+it('renders the Container component', () => {
+  const ref = React.createRef();
+  const arrowRef = React.createRef();
+  const wrapper = mount(
+    <Container
+      ref={ref}
+      arrowProps={{ ref: arrowRef, style: { left: 0, top: 0 } }}
+    >
+      foobar
+    </Container>
+  );
+  expect(wrapper).toMatchSnapshot();
+});
+
+it('forwards props to Popover', () => {
+  const wrapper = mount(
+    <Tooltip renderTooltip={() => <x-tooltip />}>
+      {({ mouseMoveBehavior }: any) => (
+        <x-content mouseMoveBehavior={mouseMoveBehavior} />
+      )}
+    </Tooltip>
+  );
+
+  expect(wrapper.find('x-content').prop('mouseMoveBehavior')).toBe(true);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1162,7 +1162,7 @@
     "@emotion/utils" "0.11.1"
     object-assign "^4.1.1"
 
-"@emotion/styled@^10.0.10":
+"@emotion/styled@^10.0.10", "@emotion/styled@^10.0.11":
   version "10.0.11"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-10.0.11.tgz#f749ca95bfe398b3e511b65ea14b16984f049e6d"
   integrity sha512-c/M/JJHTQuqdY9viSZD41ccCJDe07/VMrj+JgOcyb8uDnRAr+3cCQ03tyrgl72bQD0YWcjXHhpA7Ja9S3+vuRw==
@@ -15056,6 +15056,11 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-debounce@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-2.1.0.tgz#9b7b207fb20f29552e1d8b06fcb84ed65f9dfa7f"
+  integrity sha512-2xfUMlhgiLIp0MBHnLf1JTkeYQV8s9BfajClmNGhWvm8lqy3EGLn62Op1xbgUZ+po3YC9hIXN8HnW9B9siNbIA==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

This PR adds two new functionalities to `Popover`: delays for open and close actions, and a way to have the popover listen for "mouse outside" events to close it.
Also, we now provide the `open` and `close` callbacks along with the pre-existing `toggle`.

On top of these changes, the Tooltip component have been added to the repository.

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-popover
- @quid/react-tooltip

