### PR TITLE
Fix/tooltip and icon issues

### DIFF
--- a/packages/react-core/src/Icon/__snapshots__/index.test.js.snap
+++ b/packages/react-core/src/Icon/__snapshots__/index.test.js.snap
@@ -23,11 +23,17 @@ exports[`renders a non squared Icon 1`] = `
   name="network"
   squared={false}
 >
-  <i
+  <ForwardRef
     className="emotion-0 emotion-1"
+    name="network"
+    squared={false}
   >
-    network
-  </i>
+    <i
+      className="emotion-0 emotion-1"
+    >
+      network
+    </i>
+  </ForwardRef>
 </Icon>
 `;
 
@@ -68,10 +74,16 @@ exports[`renders the expected markup 1`] = `
   name="network"
   squared={true}
 >
-  <i
+  <ForwardRef
     className="emotion-0 emotion-1"
+    name="network"
+    squared={true}
   >
-    network
-  </i>
+    <i
+      className="emotion-0 emotion-1"
+    >
+      network
+    </i>
+  </ForwardRef>
 </Icon>
 `;

--- a/packages/react-core/src/Icon/index.js
+++ b/packages/react-core/src/Icon/index.js
@@ -16,9 +16,13 @@ type Props = {
   squared?: boolean,
 };
 
-const Icon = styled(({ name, squared, ...props }: Props) => (
-  <i {...props}>{name}</i>
-))`
+const Icon = styled(
+  React.forwardRef(({ name, squared, ...props }: Props, ref) => (
+    <i {...props} ref={ref}>
+      {name}
+    </i>
+  ))
+)`
   /* use !important to prevent issues with browser extensions that change fonts */
   font-family: 'quid-icons' !important;
   speak: none;

--- a/packages/react-forms/src/InputDate/__snapshots__/index.test.js.snap
+++ b/packages/react-forms/src/InputDate/__snapshots__/index.test.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders the expected markup 1`] = `
-.emotion-4 {
+.emotion-6 {
   margin-right: 10px;
 }
 
-.emotion-6 {
+.emotion-8 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
   font-size: 14px;
   line-height: 1.57;
@@ -31,8 +31,8 @@ exports[`renders the expected markup 1`] = `
   color: #2E3338;
 }
 
-.emotion-6:focus-within,
-.emotion-6 {
+.emotion-8:focus-within,
+.emotion-8 {
   border-color: #00c1bb;
 }
 
@@ -162,7 +162,7 @@ exports[`renders the expected markup 1`] = `
     value="2019-01-01"
   >
     <ForwardRef
-      className="emotion-8 emotion-5"
+      className="emotion-10 emotion-7"
       focus={true}
       onBlur={[Function]}
       onChange={[Function]}
@@ -174,7 +174,7 @@ exports[`renders the expected markup 1`] = `
     >
       <ForwardRef(render)>
         <Container
-          className="emotion-8 emotion-5"
+          className="emotion-10 emotion-7"
           focus={true}
           isInvalid={false}
           onBlur={[Function]}
@@ -182,7 +182,7 @@ exports[`renders the expected markup 1`] = `
           onFocus={[Function]}
         >
           <div
-            className="emotion-5 emotion-6 emotion-7"
+            className="emotion-7 emotion-8 emotion-9"
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -202,17 +202,24 @@ exports[`renders the expected markup 1`] = `
               />
             </Input>
             <Icon
-              className="emotion-4"
+              className="emotion-6"
               name="calendar"
               onClick={[Function]}
               squared={true}
             >
-              <i
+              <ForwardRef
                 className="emotion-2 emotion-3"
+                name="calendar"
                 onClick={[Function]}
+                squared={true}
               >
-                calendar
-              </i>
+                <i
+                  className="emotion-2 emotion-3"
+                  onClick={[Function]}
+                >
+                  calendar
+                </i>
+              </ForwardRef>
             </Icon>
           </div>
         </Container>

--- a/packages/react-layouts/src/Breadcrumb/__snapshots__/index.test.js.snap
+++ b/packages/react-layouts/src/Breadcrumb/__snapshots__/index.test.js.snap
@@ -66,7 +66,7 @@ exports[`renders a default NavLink 1`] = `
 `;
 
 exports[`renders the expected markup 1`] = `
-.emotion-27 {
+.emotion-35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -99,7 +99,7 @@ exports[`renders the expected markup 1`] = `
   font-weight: bold;
 }
 
-.emotion-5 {
+.emotion-7 {
   padding-left: 10px;
   padding-right: 10px;
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
@@ -144,7 +144,7 @@ exports[`renders the expected markup 1`] = `
   width: 1em;
 }
 
-.emotion-19 {
+.emotion-25 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
   font-size: 14px;
   line-height: 1.57;
@@ -163,7 +163,7 @@ exports[`renders the expected markup 1`] = `
   cursor: default;
 }
 
-.emotion-25 {
+.emotion-33 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
   font-size: 14px;
   line-height: 1.57;
@@ -213,7 +213,7 @@ exports[`renders the expected markup 1`] = `
   }
 >
   <ul
-    className="emotion-27 emotion-28"
+    className="emotion-35 emotion-36"
   >
     <NavLink
       disabled={false}
@@ -238,17 +238,23 @@ exports[`renders the expected markup 1`] = `
       key=".1"
     >
       <div
-        className="emotion-5 emotion-6"
+        className="emotion-7 emotion-8"
       >
         <Icon
           name="angle_double_right"
           squared={true}
         >
-          <i
+          <ForwardRef
             className="emotion-3 emotion-4"
+            name="angle_double_right"
+            squared={true}
           >
-            angle_double_right
-          </i>
+            <i
+              className="emotion-3 emotion-4"
+            >
+              angle_double_right
+            </i>
+          </ForwardRef>
         </Icon>
       </div>
     </Arrow>
@@ -279,17 +285,23 @@ exports[`renders the expected markup 1`] = `
       key=".3"
     >
       <div
-        className="emotion-5 emotion-6"
+        className="emotion-7 emotion-8"
       >
         <Icon
           name="angle_right"
           squared={true}
         >
-          <i
+          <ForwardRef
             className="emotion-3 emotion-4"
+            name="angle_right"
+            squared={true}
           >
-            angle_right
-          </i>
+            <i
+              className="emotion-3 emotion-4"
+            >
+              angle_right
+            </i>
+          </ForwardRef>
         </Icon>
       </div>
     </Arrow>
@@ -315,17 +327,23 @@ exports[`renders the expected markup 1`] = `
       key=".5"
     >
       <div
-        className="emotion-5 emotion-6"
+        className="emotion-7 emotion-8"
       >
         <Icon
           name="angle_right"
           squared={true}
         >
-          <i
+          <ForwardRef
             className="emotion-3 emotion-4"
+            name="angle_right"
+            squared={true}
           >
-            angle_right
-          </i>
+            <i
+              className="emotion-3 emotion-4"
+            >
+              angle_right
+            </i>
+          </ForwardRef>
         </Icon>
       </div>
     </Arrow>
@@ -337,7 +355,7 @@ exports[`renders the expected markup 1`] = `
       to="/search/review/analyze"
     >
       <a
-        className="emotion-19 emotion-1"
+        className="emotion-25 emotion-1"
       >
         ANALYZE
       </a>
@@ -346,17 +364,23 @@ exports[`renders the expected markup 1`] = `
       key=".7"
     >
       <div
-        className="emotion-5 emotion-6"
+        className="emotion-7 emotion-8"
       >
         <Icon
           name="angle_right"
           squared={true}
         >
-          <i
+          <ForwardRef
             className="emotion-3 emotion-4"
+            name="angle_right"
+            squared={true}
           >
-            angle_right
-          </i>
+            <i
+              className="emotion-3 emotion-4"
+            >
+              angle_right
+            </i>
+          </ForwardRef>
         </Icon>
       </div>
     </Arrow>
@@ -368,7 +392,7 @@ exports[`renders the expected markup 1`] = `
       to="/search/review/analyze/share"
     >
       <a
-        className="emotion-25 emotion-1"
+        className="emotion-33 emotion-1"
         href="/search/review/analyze/share"
       >
         SHARE

--- a/packages/react-layouts/src/Modal/__snapshots__/index.test.js.snap
+++ b/packages/react-layouts/src/Modal/__snapshots__/index.test.js.snap
@@ -61,7 +61,7 @@ exports[`Modal renders Header, HeaderIcon, ActionBar with different themes 1`] =
   color: #2E3338;
 }
 
-.emotion-4 {
+.emotion-6 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -99,7 +99,7 @@ exports[`Modal renders Header, HeaderIcon, ActionBar with different themes 1`] =
   title="Hello world"
 >
   <header
-    className="emotion-4 emotion-5"
+    className="emotion-6 emotion-7"
     importance="warning"
   >
     <HeaderTitle>
@@ -113,18 +113,24 @@ exports[`Modal renders Header, HeaderIcon, ActionBar with different themes 1`] =
       name={<i />}
       squared={true}
     >
-      <i
+      <ForwardRef
         className="emotion-2 emotion-3"
+        name={<i />}
+        squared={true}
       >
-        <i />
-      </i>
+        <i
+          className="emotion-2 emotion-3"
+        >
+          <i />
+        </i>
+      </ForwardRef>
     </HeaderIcon>
   </header>
 </Header>
 `;
 
 exports[`Modal renders a Modal with form 1`] = `
-.emotion-18 {
+.emotion-20 {
   width: 800px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -143,11 +149,11 @@ exports[`Modal renders a Modal with form 1`] = `
   max-height: 500px;
 }
 
-.emotion-18:focus:not(:focus-visible) {
+.emotion-20:focus:not(:focus-visible) {
   outline: 0;
 }
 
-.emotion-20 {
+.emotion-22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -168,7 +174,7 @@ exports[`Modal renders a Modal with form 1`] = `
   background-color: rgba(18,18,18,0.6);
 }
 
-.emotion-16 {
+.emotion-18 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -182,7 +188,7 @@ exports[`Modal renders a Modal with form 1`] = `
   overflow-y: auto;
 }
 
-.emotion-8 {
+.emotion-10 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
   font-size: 14px;
   line-height: 1.57;
@@ -201,14 +207,14 @@ exports[`Modal renders a Modal with form 1`] = `
   padding: 30px 100px;
 }
 
-.emotion-6 {
+.emotion-8 {
   min-height: inherit;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.emotion-14 {
+.emotion-16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -225,7 +231,7 @@ exports[`Modal renders a Modal with form 1`] = `
   border-top: 1px solid #E3E6E8;
 }
 
-.emotion-4 {
+.emotion-6 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -310,11 +316,11 @@ exports[`Modal renders a Modal with form 1`] = `
   color: #2E3338;
 }
 
-.emotion-10 {
+.emotion-12 {
   margin-right: auto;
 }
 
-.emotion-12 {
+.emotion-14 {
   margin-left: auto;
 }
 
@@ -591,14 +597,14 @@ exports[`Modal renders a Modal with form 1`] = `
       }
     >
       <div
-        className="ReactModal__Overlay ReactModal__Overlay--after-open emotion-20"
+        className="ReactModal__Overlay ReactModal__Overlay--after-open emotion-22"
         onClick={[Function]}
         onMouseDown={[Function]}
         style={Object {}}
       >
         <div
           aria-label="Did You Know...?"
-          className="ReactModal__Content ReactModal__Content--after-open emotion-18 emotion-19"
+          className="ReactModal__Content ReactModal__Content--after-open emotion-20 emotion-21"
           onClick={[Function]}
           onKeyDown={[Function]}
           onMouseDown={[Function]}
@@ -611,7 +617,7 @@ exports[`Modal renders a Modal with form 1`] = `
             isForm={true}
           >
             <form
-              className="emotion-16 emotion-17"
+              className="emotion-18 emotion-19"
             >
               <Header
                 icon="question"
@@ -619,7 +625,7 @@ exports[`Modal renders a Modal with form 1`] = `
                 title="Did You Know...?"
               >
                 <header
-                  className="emotion-4 emotion-5"
+                  className="emotion-6 emotion-7"
                   importance="info"
                 >
                   <HeaderTitle>
@@ -633,11 +639,17 @@ exports[`Modal renders a Modal with form 1`] = `
                     name="question"
                     squared={true}
                   >
-                    <i
+                    <ForwardRef
                       className="emotion-2 emotion-3"
+                      name="question"
+                      squared={true}
                     >
-                      question
-                    </i>
+                      <i
+                        className="emotion-2 emotion-3"
+                      >
+                        question
+                      </i>
+                    </ForwardRef>
                   </HeaderIcon>
                 </header>
               </Header>
@@ -645,11 +657,11 @@ exports[`Modal renders a Modal with form 1`] = `
                 centerVertically={false}
               >
                 <div
-                  className="emotion-8 emotion-9"
+                  className="emotion-10 emotion-11"
                 >
                   <Main>
                     <main
-                      className="emotion-6 emotion-7"
+                      className="emotion-8 emotion-9"
                     >
                       <span>
                         Hello, World!
@@ -664,18 +676,18 @@ exports[`Modal renders a Modal with form 1`] = `
               >
                 <ForwardRef(render)>
                   <div
-                    className="emotion-14 emotion-15"
+                    className="emotion-16 emotion-17"
                   >
                     <Right>
                       <div
-                        className="emotion-10 emotion-11"
+                        className="emotion-12 emotion-13"
                       >
                         foobar
                       </div>
                     </Right>
                     <Left>
                       <div
-                        className="emotion-12 emotion-13"
+                        className="emotion-14 emotion-15"
                       >
                         foobar
                       </div>
@@ -1601,7 +1613,7 @@ exports[`Modal renders the expected markup 1`] = `
 `;
 
 exports[`Modal renders the expected markup 2`] = `
-.emotion-21 {
+.emotion-23 {
   width: 800px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1620,11 +1632,11 @@ exports[`Modal renders the expected markup 2`] = `
   max-height: 500px;
 }
 
-.emotion-21:focus:not(:focus-visible) {
+.emotion-23:focus:not(:focus-visible) {
   outline: 0;
 }
 
-.emotion-23 {
+.emotion-25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1645,7 +1657,7 @@ exports[`Modal renders the expected markup 2`] = `
   background-color: rgba(18,18,18,0.6);
 }
 
-.emotion-19 {
+.emotion-21 {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -1659,7 +1671,7 @@ exports[`Modal renders the expected markup 2`] = `
   overflow-y: auto;
 }
 
-.emotion-8 {
+.emotion-10 {
   font-family: IBM Plex Sans,Lucida Grande,Tahoma,Verdana,Arial,sans-serif;
   font-size: 14px;
   line-height: 1.57;
@@ -1678,14 +1690,14 @@ exports[`Modal renders the expected markup 2`] = `
   padding: 30px 100px;
 }
 
-.emotion-6 {
+.emotion-8 {
   min-height: inherit;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
-.emotion-17 {
+.emotion-19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1702,19 +1714,19 @@ exports[`Modal renders the expected markup 2`] = `
   border-top: 1px solid #E3E6E8;
 }
 
-.emotion-10 {
+.emotion-12 {
   margin: 0 5px;
 }
 
-.emotion-10:first-child {
+.emotion-12:first-child {
   margin-left: 0;
 }
 
-.emotion-10:last-child {
+.emotion-12:last-child {
   margin-right: 0;
 }
 
-.emotion-4 {
+.emotion-6 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1799,11 +1811,11 @@ exports[`Modal renders the expected markup 2`] = `
   color: #2E3338;
 }
 
-.emotion-12 {
+.emotion-14 {
   margin-right: auto;
 }
 
-.emotion-15 {
+.emotion-17 {
   margin-left: auto;
 }
 
@@ -2114,14 +2126,14 @@ exports[`Modal renders the expected markup 2`] = `
       }
     >
       <div
-        className="ReactModal__Overlay ReactModal__Overlay--after-open emotion-23"
+        className="ReactModal__Overlay ReactModal__Overlay--after-open emotion-25"
         onClick={[Function]}
         onMouseDown={[Function]}
         style={Object {}}
       >
         <div
           aria-label="Did You Know...?"
-          className="ReactModal__Content ReactModal__Content--after-open emotion-21 emotion-22"
+          className="ReactModal__Content ReactModal__Content--after-open emotion-23 emotion-24"
           onClick={[Function]}
           onKeyDown={[Function]}
           onMouseDown={[Function]}
@@ -2132,7 +2144,7 @@ exports[`Modal renders the expected markup 2`] = `
         >
           <OptionalForm>
             <div
-              className="emotion-19 emotion-20"
+              className="emotion-21 emotion-22"
             >
               <Header
                 icon="question"
@@ -2140,7 +2152,7 @@ exports[`Modal renders the expected markup 2`] = `
                 title="Did You Know...?"
               >
                 <header
-                  className="emotion-4 emotion-5"
+                  className="emotion-6 emotion-7"
                   importance="info"
                 >
                   <HeaderTitle>
@@ -2154,11 +2166,17 @@ exports[`Modal renders the expected markup 2`] = `
                     name="question"
                     squared={true}
                   >
-                    <i
+                    <ForwardRef
                       className="emotion-2 emotion-3"
+                      name="question"
+                      squared={true}
                     >
-                      question
-                    </i>
+                      <i
+                        className="emotion-2 emotion-3"
+                      >
+                        question
+                      </i>
+                    </ForwardRef>
                   </HeaderIcon>
                 </header>
               </Header>
@@ -2166,11 +2184,11 @@ exports[`Modal renders the expected markup 2`] = `
                 centerVertically={false}
               >
                 <div
-                  className="emotion-8 emotion-9"
+                  className="emotion-10 emotion-11"
                 >
                   <Main>
                     <main
-                      className="emotion-6 emotion-7"
+                      className="emotion-8 emotion-9"
                     >
                       <span>
                         Hello, World!
@@ -2185,20 +2203,20 @@ exports[`Modal renders the expected markup 2`] = `
               >
                 <ForwardRef(render)>
                   <div
-                    className="emotion-17 emotion-18"
+                    className="emotion-19 emotion-20"
                   >
                     <Right>
                       <div
-                        className="emotion-12 emotion-13"
+                        className="emotion-14 emotion-15"
                       >
                         <button
-                          className="emotion-10"
+                          className="emotion-12"
                           key="1"
                         >
                           foo
                         </button>
                         <button
-                          className="emotion-10"
+                          className="emotion-12"
                           key="2"
                         >
                           foo
@@ -2207,10 +2225,10 @@ exports[`Modal renders the expected markup 2`] = `
                     </Right>
                     <Left>
                       <div
-                        className="emotion-15 emotion-16"
+                        className="emotion-17 emotion-18"
                       >
                         <button
-                          className="emotion-10"
+                          className="emotion-12"
                           key="1"
                         >
                           foo
@@ -2304,11 +2322,17 @@ exports[`Modal should match props provided to Modal 2`] = `
   name="question"
   squared={true}
 >
-  <i
+  <ForwardRef
     className="emotion-0 emotion-1"
+    name="question"
+    squared={true}
   >
-    question
-  </i>
+    <i
+      className="emotion-0 emotion-1"
+    >
+      question
+    </i>
+  </ForwardRef>
 </HeaderIcon>
 `;
 

--- a/packages/react-popover/src/index.js
+++ b/packages/react-popover/src/index.js
@@ -120,7 +120,7 @@ Container.defaultProps = {
   theme: themes.light,
 };
 
-type Helpers = {
+export type Helpers = {
   toggle: () => void,
   open: () => void,
   close: () => void,

--- a/packages/react-tooltip/src/index.js
+++ b/packages/react-tooltip/src/index.js
@@ -12,6 +12,7 @@ import styled from '@emotion/styled/macro';
 import Popover, {
   Container as PopoverContainer,
   Arrow,
+  type Helpers,
 } from '@quid/react-popover';
 
 type RenderTooltipProps = {
@@ -31,7 +32,7 @@ type Props = {
   modifiers?: Modifiers,
   eventsEnabled?: boolean,
   positionFixed?: boolean,
-  children: ({ ref: React.ElementRef<any>, toggle: () => void }) => React.Node,
+  children: ({ ref: React.ElementRef<any> } & Helpers) => React.Node,
 };
 
 const Tooltip = ({ renderTooltip, ...props }: Props) => (


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [ ] I updated the documentation and examples accordingly; N/A

## Changes description

- feat: export Helpers type from react-popover
- fix: use react-popover Helpers type to define react-tooltip render-prop
- fix: forward ref to Icon

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-core
- @quid/react-popover
- @quid/react-tooltip

