### PR TITLE
feat: add theme support for Popover and Tooltip

### DIFF
--- a/packages/react-popover/src/__snapshots__/index.test.js.snap
+++ b/packages/react-popover/src/__snapshots__/index.test.js.snap
@@ -73,6 +73,10 @@ exports[`renders the Arrow component 1`] = `
       },
       "disabled": "#8F9BA3",
       "link": "#3C8790",
+      "popover": Object {
+        "backgroundColor": "#FFFFFF",
+        "borderColor": "#E3E6E8",
+      },
       "primary": "#2E3338",
       "primaryInverse": "#E3E6E8",
       "secondary": "#6C7983",
@@ -106,9 +110,9 @@ exports[`renders the Arrow component 1`] = `
 
 exports[`renders the Container component 1`] = `
 .emotion-0 {
-  background-color: #E3E6E8;
+  background-color: #FFFFFF;
   color: #2E3338;
-  border: 1px solid #C7CCD1;
+  border: 1px solid #E3E6E8;
   border-radius: 2px;
   padding: 5px;
   -webkit-filter: drop-shadow( 0 2px 2px rgba(18,18,18,0.2) );
@@ -121,21 +125,20 @@ exports[`renders the Container component 1`] = `
   border-width: 6px;
   top: -6px;
   border-top-width: 0;
-  border-top-color: transparent;
-  border-right-color: transparent;
-  border-left-color: transparent;
+  border-color: transparent;
+  border-bottom-color: #FFFFFF;
   left: 0px;
   top: 0px;
 }
 
 .emotion-0 .e1oyuzn00 {
   border-width: 7px;
-  border-bottom-color: #C7CCD1;
+  border-bottom-color: #E3E6E8;
   left: -7px;
   top: -7px;
-  -webkit-transform: translateY( -1.5px );
-  -ms-transform: translateY( -1.5px );
-  transform: translateY( -1.5px );
+  -webkit-transform: translateY(-1.5px);
+  -ms-transform: translateY(-1.5px);
+  transform: translateY(-1.5px);
   z-index: -1;
 }
 
@@ -192,6 +195,10 @@ exports[`renders the Container component 1`] = `
       },
       "disabled": "#8F9BA3",
       "link": "#3C8790",
+      "popover": Object {
+        "backgroundColor": "#FFFFFF",
+        "borderColor": "#E3E6E8",
+      },
       "primary": "#2E3338",
       "primaryInverse": "#E3E6E8",
       "secondary": "#6C7983",

--- a/packages/react-popover/src/index.js
+++ b/packages/react-popover/src/index.js
@@ -23,6 +23,14 @@ import MouseOutside from '@quid/react-mouse-outside';
 import mergeRefs from '@quid/merge-refs';
 import useControlledState from '@quid/react-use-controlled-state';
 
+const theme = {
+  ...themes.light,
+  popover: {
+    backgroundColor: themes.light.colors.white,
+    borderColor: themes.light.colors.gray1,
+  },
+};
+
 function getOppositePlacement(placement) {
   const hash = { left: 'right', right: 'left', bottom: 'top', top: 'bottom' };
   return placement.replace(/left|right|bottom|top/g, matched => hash[matched]);
@@ -42,19 +50,19 @@ const Arrow = styled(
   width: 0;
   height: 0;
   border-style: solid;
-  border-color: ${props => props.theme.primaryInverse};
+  border-color: ${props => props.theme.popover.borderColor};
 `;
 Arrow.defaultProps = {
-  theme: themes.light,
+  theme,
 };
 
 const Container = styled('div', {
   shouldForwardProp: prop =>
     !['open', 'close', 'toggle'].includes(prop) && isPropValid(prop),
 })`
-  background-color: ${props => props.theme.primaryInverse};
+  background-color: ${props => props.theme.popover.backgroundColor};
   color: ${props => props.theme.primary};
-  border: 1px solid ${props => props.theme.colors.gray2};
+  border: 1px solid ${props => props.theme.popover.borderColor};
   border-radius: 2px;
   padding: ${props => props.theme.sizes.small};
   filter: drop-shadow(
@@ -73,42 +81,22 @@ const Container = styled('div', {
       border-width: ${props.arrowSize}px;
       ${getOppositePlacement(props.placement)}: -${props.arrowSize}px;
       border-${getOppositePlacement(props.placement)}-width: 0;
-      border-${getOppositePlacement(props.placement)}-color: transparent;
-      ${
-        ['top', 'bottom'].includes(props.placement)
-          ? css`
-              border-right-color: transparent;
-              border-left-color: transparent;
-            `
-          : css`
-              border-top-color: transparent;
-              border-bottom-color: transparent;
-            `
-      }
-
+      border-color: transparent;
+      border-${props.placement}-color: ${props.theme.popover.backgroundColor};
       left: ${props.arrowProps.style.left}px;
       top: ${props.arrowProps.style.top}px;
     }
 
     ${ArrowBorder} {
       border-width: ${props.arrowSize + 1}px;
-      border-${props.placement}-color: ${props.theme.colors.gray2};
+      border-${props.placement}-color: ${props.theme.popover.borderColor};
       left: -${props.arrowSize + 1}px;
       top: -${props.arrowSize + 1}px;
-      ${
+      transform: ${
         ['left', 'right'].includes(props.placement)
-          ? css`
-              transform: translateX(
-                ${props.placement === 'left' ? 1.5 : -1.5}px
-              );
-            `
-          : css`
-              transform: translateY(
-                ${props.placement === 'top' ? 1.5 : -1.5}px
-              );
-            `
-      }
-
+          ? `translateX(${props.placement === 'left' ? 1.5 : -1.5}px)`
+          : `translateY(${props.placement === 'top' ? 1.5 : -1.5}px)`
+      };
       z-index: -1;
     }
   `}
@@ -117,7 +105,7 @@ Container.defaultProps = {
   arrowSize: 6,
   placement: 'bottom',
   arrowProps: { style: { top: 0, left: 0 } },
-  theme: themes.light,
+  theme,
 };
 
 export type Helpers = {

--- a/packages/react-popover/src/index.md
+++ b/packages/react-popover/src/index.md
@@ -71,3 +71,12 @@ initialState = { open: false };
   )}
 </Popover>;
 ```
+
+### Theming
+
+You can override the default background and border colors of the `Container` and
+`Arrow` components exported by `@quid/react-popover` defining a `popover` property
+in your Emotion theme-provider.
+
+The `popover` property should be an object, containing a `backgroundColor` and
+`borderColor` properties, defining the colors you'd like to use.

--- a/packages/react-popover/src/index.test.js
+++ b/packages/react-popover/src/index.test.js
@@ -34,23 +34,23 @@ it('renders the Container component', () => {
 
 it('renders the Container component on different placements', () => {
   expect(mount(<Container placement="bottom" />)).toHaveStyleRule(
-    'border-right-color',
-    'transparent',
-    { target: `${Arrow}` }
-  );
-  expect(mount(<Container placement="top" />)).toHaveStyleRule(
-    'border-right-color',
-    'transparent',
+    'border-bottom-color',
+    '#FFFFFF',
     { target: `${Arrow}` }
   );
   expect(mount(<Container placement="right" />)).toHaveStyleRule(
+    'border-right-color',
+    '#FFFFFF',
+    { target: `${Arrow}` }
+  );
+  expect(mount(<Container placement="top" />)).toHaveStyleRule(
     'border-top-color',
-    'transparent',
+    '#FFFFFF',
     { target: `${Arrow}` }
   );
   expect(mount(<Container placement="left" />)).toHaveStyleRule(
-    'border-top-color',
-    'transparent',
+    'border-left-color',
+    '#FFFFFF',
     { target: `${Arrow}` }
   );
 });


### PR DESCRIPTION
You can now define a `popover` property in the Emotion theme provider to override the `backgroundColor` and `borderColor` properties of the Popover and Tooltip Container and Arrow elements.

<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

We can now easily override the Popover and Tooltip colors.

I also updated the default styles to match the spec.

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-popover
- @quid/react-tooltip

