### PR TITLE
Fix/never mix export types

### DIFF
--- a/packages/react-dropdown/src/__mocks__/DropdownWrapper.js
+++ b/packages/react-dropdown/src/__mocks__/DropdownWrapper.js
@@ -7,7 +7,7 @@
 // @flow
 
 import * as React from 'react';
-import Dropdown from '../index';
+import { Dropdown } from '../index';
 
 type State = {
   selectedItems: Array<Object>,

--- a/packages/react-dropdown/src/index.js
+++ b/packages/react-dropdown/src/index.js
@@ -190,6 +190,4 @@ const Dropdown = ({
   );
 };
 
-export { DropdownList };
-
-export default Dropdown;
+export { Dropdown, DropdownList };

--- a/packages/react-dropdown/src/index.md
+++ b/packages/react-dropdown/src/index.md
@@ -212,7 +212,7 @@ Depending by your use case, you may want to override the dropdown styles, for in
 This can be achieved by using [Emotion's "component as selector"](https://emotion.sh/docs/styled#targeting-another-emotion-component) feature:
 
 ```js static
-import Dropdown, { DropdownList } from '@quid/react-dropdown';
+import { Dropdown, DropdownList } from '@quid/react-dropdown';
 import styled from '@emotion/styled/macro';
 
 const CustomDropdown = styled(Dropdown)`

--- a/packages/react-dropdown/src/index.test.js
+++ b/packages/react-dropdown/src/index.test.js
@@ -10,7 +10,7 @@ import ReactDOM from 'react-dom';
 import { mount } from 'enzyme';
 import styled from '@emotion/styled/macro';
 import DropdownWrapper from './__mocks__/DropdownWrapper';
-import Dropdown, { DropdownList as DL } from './index';
+import { Dropdown, DropdownList as DL } from './index';
 import DropdownList, { List } from './List';
 import { Item, HIGHLIGHTED, SELECTED } from './Items';
 import { Divider } from './Categories';

--- a/packages/react-popover/src/index.js
+++ b/packages/react-popover/src/index.js
@@ -222,6 +222,4 @@ const Popover = ({
   );
 };
 
-export { Container, Arrow };
-
-export default Popover;
+export { Popover, Container, Arrow };

--- a/packages/react-popover/src/index.md
+++ b/packages/react-popover/src/index.md
@@ -22,7 +22,7 @@ state in a declarative way.
 
 ```jsx
 import { Button } from '@quid/react-core';
-import Popover, { Container, Arrow } from '.'; // @quid/react-popover
+import { Popover, Container, Arrow } from '.'; // @quid/react-popover
 
 <Popover
   renderPopover={props => (
@@ -49,7 +49,7 @@ a state change is triggered.
 
 ```jsx
 import { Button } from '@quid/react-core';
-import Popover, { Container, Arrow } from '.'; // @quid/react-popover
+import { Popover, Container, Arrow } from '.'; // @quid/react-popover
 
 initialState = { open: false };
 

--- a/packages/react-popover/src/index.test.js
+++ b/packages/react-popover/src/index.test.js
@@ -8,7 +8,7 @@
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
-import Popover, { Container, Arrow } from '.';
+import { Popover, Container, Arrow } from '.';
 
 jest.mock('use-debounce', () => ({
   useDebouncedCallback: callback => [callback, jest.fn()],

--- a/packages/react-tooltip/src/index.js
+++ b/packages/react-tooltip/src/index.js
@@ -9,7 +9,8 @@ import * as React from 'react';
 import { type Placement, type Modifiers } from 'popper.js';
 import { type PopperArrowProps } from 'react-popper';
 import styled from '@emotion/styled/macro';
-import Popover, {
+import {
+  Popover,
   Container as PopoverContainer,
   Arrow,
   type Helpers,
@@ -35,7 +36,7 @@ type Props = {
   children: ({ ref: React.ElementRef<any> } & Helpers) => React.Node,
 };
 
-const Tooltip = ({ renderTooltip, ...props }: Props) => (
+export const Tooltip = ({ renderTooltip, ...props }: Props) => (
   <Popover renderPopover={renderTooltip} mouseMoveBehavior {...props} />
 );
 Tooltip.defaultProps = {
@@ -50,5 +51,3 @@ export const Container = styled(
     </PopoverContainer>
   ))
 )``;
-
-export default Tooltip;

--- a/packages/react-tooltip/src/index.md
+++ b/packages/react-tooltip/src/index.md
@@ -21,7 +21,7 @@ state in a declarative way.
 
 ```jsx
 import { Button } from '@quid/react-core';
-import Tooltip, { Container } from '.'; // @quid/react-tooltip
+import { Tooltip, Container } from '.'; // @quid/react-tooltip
 
 <Tooltip
   renderTooltip={props => <Container {...props}>Tooltip content</Container>}
@@ -43,7 +43,7 @@ a state change is triggered.
 
 ```jsx
 import { Button } from '@quid/react-core';
-import Tooltip, { Container } from '.'; // @quid/react-tooltip
+import { Tooltip, Container } from '.'; // @quid/react-tooltip
 
 initialState = { open: false };
 

--- a/packages/react-tooltip/src/index.test.js
+++ b/packages/react-tooltip/src/index.test.js
@@ -6,13 +6,12 @@
  */
 // @flow
 import * as React from 'react';
-import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
-import Tooltip, { Container } from '.';
+import { Tooltip, Container } from '.';
 
 jest.mock('@quid/react-popover', () => ({
   __esModule: true,
-  default: ({ children, ...props }) => children(props),
+  Popover: ({ children, ...props }) => children(props),
   Container: 'x-popover-container',
   Arrow: 'x-popover-arrow',
 }));


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

With this PR packages that used mixed default and named exports now only use named exports, this because Microbundle doesn't support this scenario and it can cause confusion to UMD and CJS consumers. Also, for some reason, Jest sometimes freaks out with some of our packages sporting mixed exports.

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-dropdown
- @quid/react-tooltip
- @quid/react-popover

