### PR TITLE
feat: adds renderContent to BreadCrumb component

### DIFF
--- a/packages/react-layouts/src/Breadcrumb/Breadcrumb.md
+++ b/packages/react-layouts/src/Breadcrumb/Breadcrumb.md
@@ -34,6 +34,18 @@ const items = [
     path: 'https://quid.com',
     external: true,
   },
+  {
+    label: 'Quid custom',
+    path: 'https://quid.com',
+    external: true,
+    renderContent: ({ label, path, index, external }) => (
+      <div>
+        <a href={path}>
+          {label} {index}
+        </a>
+      </div>
+    ),
+  },
 ];
 
 <MemoryRouter>

--- a/packages/react-layouts/src/Breadcrumb/index.js
+++ b/packages/react-layouts/src/Breadcrumb/index.js
@@ -16,6 +16,7 @@ export type Props = {
   items: Array<{
     label: React$Node,
     path: string,
+    renderContent?: ({ index: number }) => React.Node,
     renderArrowIcon?: ({ index: number }) => React.Node,
     arrowIcon?: string,
     disabled?: boolean,
@@ -39,6 +40,7 @@ function genItem(
     label,
     path,
     arrowIcon = 'angle_right',
+    renderContent,
     renderArrowIcon,
     disabled = false,
     external = false,
@@ -48,20 +50,24 @@ function genItem(
   index
 ) {
   return [
-    <NavLink
-      to={path}
-      emphasized={emphasized}
-      external={external}
-      disabled={disabled}
-    >
-      {tooltip ? (
-        <span title={tooltip} id={`breadcrumb-${index}-tooltip`}>
-          {label}
-        </span>
-      ) : (
-        label
-      )}
-    </NavLink>,
+    renderContent ? (
+      renderContent({ index, path, label, disabled, external, emphasized })
+    ) : (
+      <NavLink
+        to={path}
+        emphasized={emphasized}
+        external={external}
+        disabled={disabled}
+      >
+        {tooltip ? (
+          <span title={tooltip} id={`breadcrumb-${index}-tooltip`}>
+            {label}
+          </span>
+        ) : (
+          label
+        )}
+      </NavLink>
+    ),
     renderArrowIcon ? (
       renderArrowIcon({ index })
     ) : (

--- a/packages/react-layouts/src/Breadcrumb/index.test.js
+++ b/packages/react-layouts/src/Breadcrumb/index.test.js
@@ -93,3 +93,33 @@ it('renders a custom arrowIcon', () => {
 
   expect(wrapper.find(CustomArrow)).toMatchSnapshot();
 });
+
+it('renderContent presence', () => {
+  const renderContentFn = jest.fn(() => <div id="test" />);
+  const wrapper = mount(
+    <BrowserRouter>
+      <Breadcrumb
+        items={[
+          {
+            label: 'FOO',
+            path: '/foo',
+            renderContent: renderContentFn,
+          },
+        ]}
+      />
+    </BrowserRouter>
+  );
+
+  expect(renderContentFn).toHaveBeenCalled();
+
+  expect(wrapper.exists('#test')).toBe(true);
+
+  expect(renderContentFn).toHaveBeenCalledWith({
+    index: 0,
+    label: 'FOO',
+    path: '/foo',
+    disabled: false,
+    emphasized: false,
+    external: false,
+  });
+});


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [X] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [X] I have added unit tests to cover my changes;
- [X] I updated the documentation and examples accordingly;

## Changes description

Adds `renderContent` function prop that has to return a `React.Node` to be able to customise the content of the Breadcrumb item without having a link wrapping the label. This change is backwards compatible.

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-layouts

