### PR TITLE
fix: set box-sizing to ExpandableTable cell

### DIFF
--- a/packages/react-expandable-table/src/styles.js
+++ b/packages/react-expandable-table/src/styles.js
@@ -22,6 +22,7 @@ const FLEX_ALIGN_MAP = {
 const alignToFlex = (align = 'left') => FLEX_ALIGN_MAP[align];
 
 export const ColumnCell = styled.div`
+  box-sizing: border-box;
   flex-shrink: 0;
   display: flex;
   align-items: center;


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes; N/A
- [x] I updated the documentation and examples accordingly;

## Changes description

Without this fix, consumers have to manually define the `*, *::before, *::after { box-sizing: none; }` in their application.

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-expandable-table

