### PR TITLE
fix: loosen emotion/styled-base version requirement

### DIFF
--- a/packages/react-dropdown/package.json
+++ b/packages/react-dropdown/package.json
@@ -30,7 +30,7 @@
     "@emotion/core": "^10.0.6",
     "@emotion/css": "^10.0.6",
     "@emotion/styled": "^10.0.6",
-    "@emotion/styled-base": "10.0.4",
+    "@emotion/styled-base": "^10.0.4",
     "@quid/react-core": "^3.3.0",
     "@quid/theme": "^3.3.0",
     "color": "^3.1.0",


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes; N/A
- [x] I updated the documentation and examples accordingly;

## Changes description

Now we allow a wider version range for the @emotion/styled-base dependency.
This allows consumers to use a single version for several packages that rely on the same dependency.

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-dropdown

