### PR TITLE
(AF-978) fix: checks if the current is valid for the InputDate

### DIFF
--- a/packages/react-forms/src/InputDate/InputDateWithCalendar.test.js
+++ b/packages/react-forms/src/InputDate/InputDateWithCalendar.test.js
@@ -10,6 +10,19 @@ import { mount } from 'enzyme';
 import InputDate from './';
 
 describe('InputDate calendar tests', () => {
+  const RealDate = Date;
+  function mockDate(isoDate) {
+    global.Date = class extends RealDate {
+      constructor() {
+        return new RealDate(isoDate);
+      }
+    };
+  }
+
+  afterEach(() => {
+    global.Date = RealDate;
+  });
+
   it('checks if onCalendarChange is called when calendar arrow is clicked', () => {
     const handleCalendarChange = jest.fn();
     const wrapper = mount(
@@ -128,5 +141,42 @@ describe('InputDate calendar tests', () => {
         .find('Year')
         .text()
     ).toBe('October 2018');
+  });
+
+  it('wrong value given to the input will not cause calendar picker error', () => {
+    const wrapper = mount(
+      <InputDate value="2019-02-01" onChange={jest.fn()} defaultIsOpen={true} />
+    );
+
+    wrapper
+      .find('input')
+      .simulate('change', { target: { value: '0019-10-01' } });
+
+    expect(
+      wrapper
+        .find('[data-context="calendar"]')
+        .find('Navigator')
+        .find('Year')
+        .text()
+    ).toBe('February 2019');
+  });
+
+  it('wrong value given to the input and current will not cause calendar picker error', () => {
+    mockDate('2019-03-01T10:00:00z');
+    const wrapper = mount(
+      <InputDate value="0000-XX-00" onChange={jest.fn()} defaultIsOpen={true} />
+    );
+
+    wrapper
+      .find('input')
+      .simulate('change', { target: { value: '0019-10-01' } });
+
+    expect(
+      wrapper
+        .find('[data-context="calendar"]')
+        .find('Navigator')
+        .find('Year')
+        .text()
+    ).toBe('March 2019');
   });
 });

--- a/packages/react-forms/src/InputDate/index.js
+++ b/packages/react-forms/src/InputDate/index.js
@@ -66,6 +66,7 @@ const InputDate = ({
   );
 
   const current = parse(baseCurrent);
+  const isCurrentValid = !isNaN(current.getTime());
 
   const handleOpen = useCallback(() => setOpen(true), [setOpen]);
   const handleClose = useCallback(() => setOpen(false), [setOpen]);
@@ -97,8 +98,10 @@ const InputDate = ({
 
   const handleInputChange = useCallback(
     (evt: SyntheticInputEvent<HTMLInputElement>) => {
-      onChange(evt.target.value);
-      setCurrentOnValueChange(evt.target.value);
+      if (evt.target.value) {
+        onChange(evt.target.value);
+        setCurrentOnValueChange(evt.target.value);
+      }
     },
     [onChange, setCurrentOnValueChange]
   );
@@ -149,7 +152,13 @@ const InputDate = ({
               {({ ref, style }) => (
                 <Calendar
                   onChangeCurrent={handleCurrentChange}
-                  current={current}
+                  current={
+                    isCurrentValid
+                      ? current
+                      : isDateValid
+                      ? dateValue
+                      : new Date()
+                  }
                   onSelect={handleSelect}
                   selected={isDateValid ? dateValue : undefined}
                   minDate={min ? new Date(min) : undefined}

--- a/packages/react-forms/src/InputDate/index.js
+++ b/packages/react-forms/src/InputDate/index.js
@@ -98,6 +98,7 @@ const InputDate = ({
 
   const handleInputChange = useCallback(
     (evt: SyntheticInputEvent<HTMLInputElement>) => {
+      // istanbul ignore else (this is too DOM related)
       if (evt.target.value) {
         onChange(evt.target.value);
         setCurrentOnValueChange(evt.target.value);


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [X] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [X] I have added unit tests to cover my changes;
- [X] I updated the documentation and examples accordingly;

## Changes description
User could type in an invalid date date would cause error. This adds handling for those cases.
Not sure if test is needed.
## Affected packages

<!-- List below all the affected packages -->

- @quid/react-forms - InputDate

