### PR TITLE
fix: trigger change event on InputNumber step up/down

### DIFF
--- a/packages/react-forms/src/InputNumber/index.js
+++ b/packages/react-forms/src/InputNumber/index.js
@@ -16,6 +16,7 @@ type Props = {
   disabled?: boolean,
   readOnly?: boolean,
   unit?: string,
+  onChange?: (SyntheticInputEvent<any> | Event) => void,
 };
 
 const Addon = styled.div`
@@ -45,8 +46,21 @@ const Caret = styled.button`
 `;
 
 const InputNumber = styled(
-  ({ step = 1, disabled = false, readOnly = false, unit, ...props }: Props) => {
+  ({
+    step = 1,
+    disabled = false,
+    readOnly = false,
+    unit,
+    onChange,
+    ...props
+  }: Props) => {
     const input = React.createRef();
+    const dispatchChange = React.useCallback(() => {
+      const event = new Event('change');
+      input.current && input.current.dispatchEvent(event);
+      onChange && onChange(event);
+    }, [input, onChange]);
+
     return (
       <InputText
         ref={input}
@@ -60,19 +74,26 @@ const InputNumber = styled(
             <Addon className={marginRightClass}>
               <Caret
                 disabled={disabled || readOnly}
-                onClick={() => input.current && input.current.stepUp(step)}
+                onClick={() => {
+                  input.current && input.current.stepUp(step);
+                  dispatchChange();
+                }}
               >
                 <Icon name="caret_up" />
               </Caret>
               <Caret
                 disabled={disabled || readOnly}
-                onClick={() => input.current && input.current.stepDown(step)}
+                onClick={() => {
+                  input.current && input.current.stepDown(step);
+                  dispatchChange();
+                }}
               >
                 <Icon name="caret_down" />
               </Caret>
             </Addon>
           </React.Fragment>
         )}
+        onChange={onChange}
         {...props}
       />
     );

--- a/packages/react-forms/src/InputNumber/index.test.js
+++ b/packages/react-forms/src/InputNumber/index.test.js
@@ -15,27 +15,37 @@ it('renders the expected markup', () => {
 });
 
 it('increments on click on up arrow', () => {
-  const stepUp = jest.fn();
-  const wrapper = mount(<InputNumber defaultValue={0} />);
-  wrapper.find('input').getDOMNode().stepUp = stepUp;
+  const handleChange = jest.fn();
+  const wrapper = mount(
+    <InputNumber defaultValue={0} onChange={handleChange} />
+  );
+  const input = wrapper.find('input').getDOMNode();
+  input.stepUp = jest.fn(() => (input.value = String(Number(input.value) + 1)));
   wrapper
     .find('button')
     .at(0)
     .simulate('click');
 
-  expect(stepUp).toBeCalled();
-  expect(stepUp.mock.calls.length).toBe(1);
+  expect(input.stepUp).toBeCalledTimes(1);
+  expect(handleChange).toBeCalledTimes(1);
+  expect(handleChange.mock.calls[0][0].target.value).toBe('1');
 });
 
 it('decrements on click on down arrow', () => {
-  const stepDown = jest.fn();
-  const wrapper = mount(<InputNumber defaultValue={0} />);
-  wrapper.find('input').getDOMNode().stepDown = stepDown;
+  const handleChange = jest.fn();
+  const wrapper = mount(
+    <InputNumber defaultValue={0} onChange={handleChange} />
+  );
+  const input = wrapper.find('input').getDOMNode();
+  input.stepDown = jest.fn(
+    () => (input.value = String(Number(input.value) - 1))
+  );
   wrapper
     .find('button')
     .at(1)
     .simulate('click');
 
-  expect(stepDown).toBeCalled();
-  expect(stepDown.mock.calls.length).toBe(1);
+  expect(input.stepDown).toBeCalledTimes(1);
+  expect(handleChange).toBeCalledTimes(1);
+  expect(handleChange.mock.calls[0][0].target.value).toBe('-1');
 });


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

<!-- Describe what your PR changes -->

Previously if you clicked on the InputNumber arrows, the `change` event wasn't triggered.

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-forms

