### PR TITLE
fix: controlled InputRange and performance improvements

### DIFF
--- a/packages/react-forms/package.json
+++ b/packages/react-forms/package.json
@@ -35,7 +35,8 @@
     "emotion": "^10.0.5",
     "nanoid": "^2.0.0",
     "react-popper": "^1.3.3",
-    "react-resize-aware": "^2.7.2",
+    "react-range": "^1.4.1",
+    "react-resize-aware": "^3.0.0-beta.3",
     "react-router-dom": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/react-forms/src/InputRange/Handle.js
+++ b/packages/react-forms/src/InputRange/Handle.js
@@ -77,16 +77,11 @@ const Handle = styled(
   margin-top: ${HANDLE_SIZE / -2}px;
   cursor: default;
   z-index: 2;
-  transform: translateX(calc(${props => props.offset}px - 50%));
   &::before {
     content: '';
     display: block;
     background-color: ${wf(props =>
-      props.disabled
-        ? TRACK_BACKGROUND(props)
-        : props.zero
-        ? 'transparent'
-        : 'currentColor'
+      props.disabled ? TRACK_BACKGROUND(props) : 'currentColor'
     )};
     width: ${HANDLE_SIZE}px;
     height: ${HANDLE_SIZE}px;
@@ -94,13 +89,6 @@ const Handle = styled(
     border-radius: 50%;
     transition: transform 0.2s ease-in-out, width 0.2s ease-in-out,
       height 0.2s ease-in-out;
-    ${wf(
-      props =>
-        props.zero &&
-        css`
-          border: 1px solid ${TRACK_BACKGROUND(props)};
-        `
-    )}
   }
 
   &:active::before {

--- a/packages/react-forms/src/InputRange/InputRange.md
+++ b/packages/react-forms/src/InputRange/InputRange.md
@@ -1,7 +1,7 @@
 The `InputRange` component aims to provide an interface compatible with [`input[type=range]`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range).
 
 ```js
-<InputRange step={5} name="single1" onChange={console.log} />
+<InputRange step={5} name="uncontrolled-with-step" onChange={console.log} />
 ```
 
 All the properties supported by the HTML element are supported by `InputRange`, but,
@@ -10,14 +10,14 @@ additionally, this component supports two values at the same time.
 The `onChange` handler in this case will return an object containing the properties
 `start` and `end`, rather than a single number.
 
-Note that in order to switch the component behavior to the double valued alternative
-you must define a `defaultValue` defining the `start` and `end` properties, or define
-its `value`.
+Rather than expecting a `value` property, this component expects a `values` one, which is an array of 1 or 2 numbers.
+If only one number is provided, the component will render a single handle, when two are provided, the component will switch
+to the two handles layout.
 
 ```js
 <InputRange
-  defaultValue={{ start: 10, end: 40 }}
-  name="double1"
+  defaultValues={[10, 40]}
+  name="uncontrolled-double"
   onChange={console.log}
 />
 ```
@@ -26,5 +26,29 @@ As with the HTML version, you can provide a `discrete` boolean property to displ
 some little ticks across the bar to show the valid and selectionable values.
 
 ```js
-<InputRange step={5} defaultValue={0} name="single2" discrete />
+<InputRange
+  step={5}
+  defaultValues={[0]}
+  name="uncontrolled-discrete"
+  discrete
+/>
 ```
+
+This component can be used either as a [fully controlled][controlled-components]
+or [fully uncontrolled][uncontrolled-components] component:
+
+```js
+initialState = {
+  values: [0],
+};
+
+<InputRange
+  values={state.values}
+  name="controlled-single"
+  onChange={values => setState({ values })}
+  max={100}
+/>;
+```
+
+[controlled-components]: https://reactjs.org/docs/forms.html#controlled-components
+[uncontrolled-components]: https://reactjs.org/docs/uncontrolled-components.html

--- a/packages/react-forms/src/InputRange/__snapshots__/index.test.js.snap
+++ b/packages/react-forms/src/InputRange/__snapshots__/index.test.js.snap
@@ -76,13 +76,7 @@ exports[`renders an InputRange 1`] = `
   }
 }
 
-.emotion-22 {
-  position: relative;
-  height: 12px;
-  isolation: isolate;
-}
-
-.emotion-8 {
+.emotion-9 {
   position: relative;
   top: 50%;
   background-position: center;
@@ -95,7 +89,7 @@ exports[`renders an InputRange 1`] = `
   transform: translateY(-50%);
 }
 
-.emotion-8::before {
+.emotion-9::before {
   content: '';
   position: absolute;
   height: 6px;
@@ -135,7 +129,7 @@ exports[`renders an InputRange 1`] = `
   color: #6C7983;
 }
 
-.emotion-10 {
+.emotion-13 {
   color: #00c1bb;
   top: 50%;
   left: 0;
@@ -145,12 +139,9 @@ exports[`renders an InputRange 1`] = `
   margin-top: -3px;
   cursor: default;
   z-index: 2;
-  -webkit-transform: translateX(calc(0px - 50%));
-  -ms-transform: translateX(calc(0px - 50%));
-  transform: translateX(calc(0px - 50%));
 }
 
-.emotion-10::before {
+.emotion-13::before {
   content: '';
   display: block;
   background-color: currentColor;
@@ -165,7 +156,7 @@ exports[`renders an InputRange 1`] = `
   transition: transform 0.2s ease-in-out,width 0.2s ease-in-out,height 0.2s ease-in-out;
 }
 
-.emotion-10:active::before {
+.emotion-13:active::before {
   -webkit-transform: scale(3);
   -ms-transform: scale(3);
   transform: scale(3);
@@ -173,281 +164,136 @@ exports[`renders an InputRange 1`] = `
   transition-delay: 0s;
 }
 
-.emotion-10:focus {
+.emotion-13:focus {
   outline: 0;
 }
 
-.emotion-10:focus-visible::before {
+.emotion-13:focus-visible::before {
   -webkit-animation: animation-0 1s infinite alternate ease-in-out;
   animation: animation-0 1s infinite alternate ease-in-out;
 }
 
-.emotion-20 {
-  pointer-events: none;
-  z-index: 1;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  position: absolute;
-  left: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.emotion-12 {
-  height: 6px;
-  width: 2px;
-  position: relative;
-  -webkit-transform: translateX(1px) translateY(3px);
-  -ms-transform: translateX(1px) translateY(3px);
-  transform: translateX(1px) translateY(3px);
-  color: #00c1bb;
-  border-radius: 2px;
-  background-color: #6C7983;
-  opacity: 0;
-}
-
-.emotion-12:first-of-type {
-  -webkit-transform: translateY(3px);
-  -ms-transform: translateY(3px);
-  transform: translateY(3px);
-}
-
-.emotion-14 {
-  height: 6px;
-  width: 2px;
-  position: relative;
-  -webkit-transform: translateX(1px) translateY(3px);
-  -ms-transform: translateX(1px) translateY(3px);
-  transform: translateX(1px) translateY(3px);
-  color: #00c1bb;
-  border-radius: 2px;
-  background-color: #6C7983;
-  opacity: 1;
-}
-
-.emotion-14:first-of-type {
-  -webkit-transform: translateY(3px);
-  -ms-transform: translateY(3px);
-  transform: translateY(3px);
-}
-
 <InputRange
-  defaultValue={0}
-  disabled={false}
-  discrete={true}
-  max={10}
-  min={0}
   name="x"
-  readOnly={false}
-  step={5}
 >
-  <Container
-    aria-disabled={false}
-    aria-orientation="horizontal"
-    aria-readonly={false}
-    aria-valuemax={10}
-    aria-valuemin={0}
-    aria-valuetext="0"
-    as={[Function]}
-    defaultValue={0}
-    onResize={[Function]}
-    role="slider"
+  <x-range
+    disabled={false}
+    max={100}
+    min={0}
+    onChange={[Function]}
+    step={1}
   >
-    <div
-      aria-disabled={false}
-      aria-orientation="horizontal"
-      aria-readonly={false}
-      aria-valuemax={10}
-      aria-valuemin={0}
-      aria-valuetext="0"
-      className="emotion-22 emotion-23"
-      defaultValue={0}
-      role="slider"
+    <Track
+      className="emotion-11 emotion-8"
+      disabled={false}
+      style={
+        Object {
+          "zIndex": 0,
+        }
+      }
     >
-      <object
-        aria-hidden={true}
-        onLoad={[Function]}
+      <div
+        className="emotion-8 emotion-9 emotion-10"
+        disabled={false}
         style={
           Object {
-            "display": "block",
-            "height": "100%",
-            "left": 0,
-            "opacity": 0,
-            "overflow": "hidden",
-            "pointerEvents": "none",
-            "position": "absolute",
-            "top": 0,
-            "width": "100%",
-            "zIndex": -1,
+            "zIndex": 0,
           }
         }
-        tabIndex={-1}
-        type="text/html"
-      />
-      <Track
-        data-action="click-track"
-        disabled={false}
-        key=".0"
-        onMouseDown={[Function]}
       >
-        <div
-          className="emotion-8 emotion-9"
-          data-action="click-track"
-          disabled={false}
-          onMouseDown={[Function]}
+        <Segment
+          as={[Function]}
+          key="2"
+          on={true}
         >
-          <Segment
-            as={[Function]}
-            key="2"
-            on={true}
+          <svg
+            className="emotion-2 emotion-3"
+            height="100"
+            width="100"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              className="emotion-2 emotion-3"
-              height="100"
-              width="100"
-              xmlns="http://www.w3.org/2000/svg"
+            <Rect
+              disabled={false}
+              offset={0}
+              width={0}
             >
-              <Rect
+              <rect
+                className="emotion-0 emotion-1"
                 disabled={false}
+                fill="currentColor"
+                height={2}
                 offset={0}
+                rx={1}
+                ry={1}
                 width={0}
-              >
-                <rect
-                  className="emotion-0 emotion-1"
-                  disabled={false}
-                  fill="currentColor"
-                  height={2}
-                  offset={0}
-                  rx={1}
-                  ry={1}
-                  width={0}
-                  x={0}
-                />
-              </Rect>
-            </svg>
-          </Segment>
-          <Segment
-            as={[Function]}
-            key="3"
+                x={0}
+              />
+            </Rect>
+          </svg>
+        </Segment>
+        <Segment
+          as={[Function]}
+          key="3"
+        >
+          <svg
+            className="emotion-6 emotion-3"
+            height="100"
+            width="100"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              className="emotion-6 emotion-3"
-              height="100"
-              width="100"
-              xmlns="http://www.w3.org/2000/svg"
+            <Rect
+              disabled={true}
+              offset={0}
+              width={1000}
             >
-              <Rect
+              <rect
+                className="emotion-4 emotion-1"
                 disabled={true}
+                fill="currentColor"
+                height={2}
                 offset={0}
-                width={0}
-              >
-                <rect
-                  className="emotion-4 emotion-1"
-                  disabled={true}
-                  fill="currentColor"
-                  height={2}
-                  offset={0}
-                  rx={1}
-                  ry={1}
-                  width={0}
-                  x={0}
-                />
-              </Rect>
-            </svg>
-          </Segment>
-        </div>
-      </Track>
+                rx={1}
+                ry={1}
+                width={1000}
+                x={0}
+              />
+            </Rect>
+          </svg>
+        </Segment>
+      </div>
+    </Track>
+    <div
+      style={
+        Object {
+          "position": "absolute",
+          "transform": undefined,
+          "zIndex": 1,
+        }
+      }
+    >
       <Handle
         disabled={false}
-        dragging={false}
-        key=".1"
-        name="x"
-        offset={0}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onMouseDown={[Function]}
+        index={0}
+        name="xundefined"
         readOnly={false}
-        value={0}
+        style={Object {}}
       >
         <div
-          className="emotion-10 emotion-11"
+          className="emotion-13 emotion-14"
           data-action="drag-handle"
-          data-value={0}
-          offset={0}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseDown={[Function]}
+          index={0}
+          style={Object {}}
           tabIndex={0}
         >
           <input
             disabled={false}
-            name="x"
+            name="xundefined"
             readOnly={false}
             type="hidden"
-            value={0}
           />
         </div>
       </Handle>
-      <StepTicks
-        hidden={
-          Array [
-            0,
-          ]
-        }
-        key=".2"
-        max={10}
-        min={0}
-        step={5}
-      >
-        <div
-          className="emotion-20 emotion-21"
-        >
-          <Tick
-            hidden={true}
-            key="0"
-          >
-            <div
-              className="emotion-12 emotion-13"
-              hidden={true}
-            />
-          </Tick>
-          <Tick
-            hidden={false}
-            key="1"
-          >
-            <div
-              className="emotion-14 emotion-13"
-              hidden={false}
-            />
-          </Tick>
-          <Tick
-            hidden={false}
-            key="2"
-          >
-            <div
-              className="emotion-14 emotion-13"
-              hidden={false}
-            />
-          </Tick>
-          <Tick
-            hidden={false}
-            key="3"
-          >
-            <div
-              className="emotion-14 emotion-13"
-              hidden={false}
-            />
-          </Tick>
-        </div>
-      </StepTicks>
     </div>
-  </Container>
+  </x-range>
 </InputRange>
 `;

--- a/packages/react-forms/src/InputRange/index.js
+++ b/packages/react-forms/src/InputRange/index.js
@@ -6,552 +6,143 @@
  */
 // @flow
 import * as React from 'react';
-import ResizeAware from 'react-resize-aware';
+import { Range } from 'react-range';
+import useControlledState from '@quid/react-use-controlled-state';
 import styled from '@emotion/styled/macro';
-import { withFallback as wf } from '@quid/theme';
-import {
-  TRACK_BACKGROUND,
-  Container,
-  Track,
-  Segment,
-  StepTicks,
-} from './styles';
+import useResizeAware from 'react-resize-aware';
 import Handle from './Handle';
-
-export type ComputedValue = { start: number, end: number };
-export type Value = number | { start?: number, end?: number };
-
-// We need this to give a proper default value to `track`
-// otherwise during tests something may fail because of the
-// jsdom quirks that make the component lifecycle execute without
-// having the root node initialized
-const div = document.createElement('div');
-
-export const handles = {
-  START: 'start',
-  END: 'end',
-};
-
-export const keys = {
-  RIGHT: 39,
-  LEFT: 37,
-};
-
-export function fromPercentToPixel(percent: number, width: number): number {
-  return (width / 100) * percent;
-}
-
-function hasName(name): boolean %checks {
-  return typeof name === 'string';
-}
-
-// We used to use CSS gradients with hard stops, but this bug is
-// producing a bad visual result (crbug.com/696603)
-export function wrapWithSvg(
-  content: React$Element<any>,
-  { className, on, ...props }: { className?: string, on: boolean }
-) {
-  return (
-    <svg
-      className={className}
-      xmlns="http://www.w3.org/2000/svg"
-      width="100"
-      height="100"
-      {...props}
-    >
-      {content}
-    </svg>
-  );
-}
-
-export const Rect = styled(props => (
-  <rect
-    {...props}
-    fill="currentColor"
-    height={2}
-    width={Math.max(props.width, 0)}
-    x={Math.max(props.offset, 0)}
-    rx={1}
-    ry={1}
-  />
-))`
-  color: ${wf(props =>
-    props.disabled ? TRACK_BACKGROUND(props) : props.theme.selected
-  )};
-`;
-
-export function drawSegment(width: number, offset: number, disabled: boolean) {
-  return (props: Object) =>
-    wrapWithSvg(
-      <Rect width={width} offset={offset} disabled={disabled} />,
-      props
-    );
-}
-
-export function getDecimals(num: number) {
-  const stepArr = num.toString().split('.');
-  return stepArr[1] ? stepArr[1].length : 0;
-}
-
-export function toFixed(num: number, decimals: number) {
-  const parts = num.toString().split('.');
-  return `${parts[0]}.${(parts[1] || '00000000').slice(0, decimals)}`;
-}
-
-export function valueToObject(value?: Value): Object {
-  if (value === undefined) {
-    return {};
-  }
-
-  if (typeof value === 'object') {
-    if (
-      value.hasOwnProperty(handles.START) &&
-      !isNaN(value[handles.START]) &&
-      value.hasOwnProperty(handles.END) &&
-      !isNaN(value[handles.END])
-    ) {
-      return {
-        [handles.START]: +value[handles.START],
-        [handles.END]: +value[handles.END],
-      };
-    } else if (
-      value.hasOwnProperty(handles.START) &&
-      !isNaN(value[handles.START])
-    ) {
-      return {
-        [handles.START]: +value[handles.START],
-      };
-    } else {
-      return {
-        [handles.END]: +value[handles.END],
-      };
-    }
-  }
-
-  return {
-    [handles.START]: +value,
-  };
-}
-
-export function computeW3cDefaultValue(min: number, max: number) {
-  return max > min ? min + (max - min) / 2 : min;
-}
-
-export function isItTwoHandled(value: ComputedValue) {
-  return !isNaN(value[handles.END]);
-}
-
-export function areValuesEqual(a?: Value, b?: Value): boolean {
-  const compA = valueToObject(a);
-  const compB = valueToObject(b);
-
-  return (
-    compA[handles.START] === compB[handles.START] &&
-    compA[handles.END] === compB[handles.END]
-  );
-}
+import { HANDLE_SIZE, Segment, StepTicks } from './styles';
+import { fromPercentToPixel, drawSegment } from './utils';
 
 type Props = {
-  onChange?: Function,
-  value?: Value,
-  defaultValue?: Value,
-  name?: string,
-  min: number,
-  max: number,
-  step: number,
-  readOnly: boolean,
-  disabled: boolean,
-  discrete: boolean,
+  onChange?: (Array<number>) => void,
+  values?: Array<number>,
+  defaultValues?: Array<number>,
+  name: string,
+  min?: number,
+  max?: number,
+  step?: number,
+  readOnly?: boolean,
+  disabled?: boolean,
+  discrete?: boolean,
   className?: string,
 };
+export const Track = styled.div`
+  position: relative;
+  top: 50%;
+  background-position: center;
+  background-size: 100% 2px;
+  background-repeat: no-repeat;
+  height: 2px;
+  border-radius: 2px;
+  transform: translateY(-50%);
 
-type Updater = () => Object;
-type HandleType = 'start' | 'end';
-type State = {
-  width: number,
-  value?: Object,
-  dragging: boolean,
-  activeHandle: HandleType,
-  stepLen: number,
-  fontSize: number,
-};
-
-// The following component relies on a lot of DOM APIs to work, I'm not able
-// to test it with Jest and JSDOM unfortunately
-/* istanbul ignore next */
-class Inner extends React.PureComponent<Props, State> {
-  track: HTMLElement = div;
-
-  static defaultProps = {
-    min: 0,
-    max: 100,
-    step: 1,
-    readOnly: false,
-    disabled: false,
-    discrete: false,
-  };
-
-  // Don't use state because
-  // 1. We don't care/want to re-render on each pos update
-  // 2. We need this value to be updated istantly
-  pos = 0;
-
-  state = {
-    width: 0,
-    value: undefined,
-    dragging: false,
-    activeHandle: handles.START,
-    stepLen: 0,
-    fontSize: 13,
-  };
-
-  uncontrolledOnChange = (updater: Updater) => {
-    const prevValue = { ...this.state.value };
-    this.setState(updater, () => {
-      const isTwoHandled = this.state.value
-        ? isItTwoHandled(this.state.value)
-        : false;
-      if (this.props.onChange && !areValuesEqual(prevValue, this.state.value)) {
-        this.props.onChange(
-          // $FlowFixMe(fzivolo): need better type checking for `isTwoHandled`, just being lazy
-          isTwoHandled ? this.state.value : this.state.value.start
-        );
-      }
-    });
-  };
-
-  controlledOnChange = (updater: Updater) => {
-    const { value } = updater();
-    const isTwoHandled = isItTwoHandled(value);
-    const newValue = isTwoHandled ? value : value[handles.START];
-    if (this.props.onChange && !areValuesEqual(this.props.value, newValue)) {
-      this.props.onChange(isTwoHandled ? newValue : newValue.start);
-    }
-  };
-
-  get onChange(): Updater => void {
-    return this.props.onChange &&
-      (!isNaN(valueToObject(this.props.value)[handles.START]) ||
-        !isNaN(valueToObject(this.props.value)[handles.END]))
-      ? this.controlledOnChange
-      : this.uncontrolledOnChange;
+  &::before {
+    content: '';
+    position: absolute;
+    height: ${props => (props.disabled ? HANDLE_SIZE / 1.5 : HANDLE_SIZE)}px;
+    width: 100%;
+    transform: translateY(-25%);
   }
+`;
 
-  handleMouseDown = (
-    { clientX: pos }: { clientX: number },
-    activeHandle: HandleType
-  ) => {
-    if (this.props.disabled || this.props.readOnly) {
-      return;
-    }
-
-    this.updatePos(pos);
-    this.setState({ dragging: true, activeHandle });
-  };
-
-  handleMouseMove = (evt: MouseEvent | Object) => {
-    const { clientX: curPos } = evt;
-    const {
-      track,
-      pos,
-      state: { dragging, stepLen, activeHandle },
-    } = this;
-
-    if (track && dragging) {
-      const { left } = track.getBoundingClientRect();
-
-      // This is used to avoid unwanted text selection while dragging
-      evt.preventDefault && evt.preventDefault();
-
-      const diff = curPos - pos;
-      const change = diff / stepLen;
-
-      const currentValue = this.computedValue[activeHandle];
-      const newValue =
-        Math.round((currentValue + change) / this.props.step) * this.props.step;
-
-      this.updatePos(left + (newValue - this.props.min) * stepLen);
-      this.updateValue(newValue);
-    }
-  };
-
-  handleMouseUp = () => this.setState({ dragging: false });
-
-  handleTrackMouseDown = ({ clientX }: { clientX: number }) => {
-    if (this.props.disabled || this.props.readOnly) {
-      return;
-    }
-
-    const { min } = this.props;
-    const { stepLen } = this.state;
-    const { left } = this.track.getBoundingClientRect();
-    const value = this.computedValue;
-    const startOffset = stepLen * value[handles.START];
-    const endOffset = stepLen * value[handles.END];
-    const middleOffset = startOffset + (endOffset - startOffset) / 2;
-    const curPos = clientX - left;
-
-    let activeHandle;
-    if (curPos > middleOffset && value[handles.END]) {
-      activeHandle = handles.END;
-    } else {
-      activeHandle = handles.START;
-    }
-    this.updatePos(left + (value[activeHandle] - min) * stepLen);
-
-    this.setState({ dragging: true, activeHandle }, () => {
-      this.handleMouseMove({ clientX });
-    });
-  };
-
-  handleKeyDown = ({ which }: KeyboardEvent) => {
-    if (this.props.disabled || this.props.readOnly) {
-      return;
-    }
-
-    const { activeHandle } = this.state;
-    const { step } = this.props;
-
-    if (which === keys.LEFT) {
-      this.updateValue(this.computedValue[activeHandle] - step);
-    } else if (which === keys.RIGHT) {
-      this.updateValue(this.computedValue[activeHandle] + step);
-    }
-  };
-
-  updateValue = (newValue: number) =>
-    this.onChange((state = this.state) => {
-      const safeNewValue =
-        Math.round(
-          parseFloat(toFixed(newValue, getDecimals(this.props.step))) /
-            this.props.step
-        ) * this.props.step;
-
-      const { activeHandle, value = this.computedValue } = state;
-      const { min, max } = this.props;
-
-      const activeHandleValue =
-        activeHandle === handles.START
-          ? Math.min(
-              !isNaN(value[handles.END]) ? value[handles.END] : max,
-              Math.max(min, safeNewValue)
-            )
-          : Math.max(Math.min(max, safeNewValue), value[handles.START]);
-
-      return {
-        value: {
-          ...value,
-          [activeHandle]: activeHandleValue,
-        },
-      };
-    });
-
-  updatePos = (pos: number) => {
-    const { left, right } = this.track.getBoundingClientRect();
-    this.pos = Math.max(Math.min(pos, right), left);
-  };
-
-  computeSizes = () => {
-    this.setState((state, { min, max }) => ({
-      width: this.track.offsetWidth,
-      stepLen: this.track.offsetWidth / (max - min),
-      fontSize: Number(
-        window
-          .getComputedStyle(this.track)
-          .getPropertyValue('font-size')
-          .replace('px', '')
-      ),
-    }));
-  };
-
-  get computedValue(): ComputedValue {
-    const { value, defaultValue, min, max } = this.props;
-
-    const stateValueObj = valueToObject(this.state.value);
-    const propsValueObj = valueToObject(value);
-    const defaultValueObj = valueToObject(defaultValue);
-    const w3cDefaultValue = valueToObject(computeW3cDefaultValue(min, max));
-
-    // If it's a controlled input, use `value`
-    // If there's already a `value` in state, use it
-    // If it's an uncontrolled input, use `defaultValue` as initial value
-    // If nothing is defined, we fallback to the default defined by W3C
-    return {
-      [handles.START]: !isNaN(propsValueObj[handles.START])
-        ? propsValueObj[handles.START]
-        : !isNaN(stateValueObj[handles.START])
-        ? stateValueObj[handles.START]
-        : !isNaN(defaultValueObj[handles.START])
-        ? defaultValueObj[handles.START]
-        : w3cDefaultValue[handles.START],
-      [handles.END]: !isNaN(propsValueObj[handles.END])
-        ? propsValueObj[handles.END]
-        : !isNaN(stateValueObj[handles.END])
-        ? stateValueObj[handles.END]
-        : !isNaN(defaultValueObj[handles.END])
-        ? defaultValueObj[handles.END]
-        : w3cDefaultValue[handles.END],
-    };
-  }
-
-  getSegments = (isTwoHandled: boolean) => {
-    const { min, max, disabled, readOnly } = this.props;
-    const { width, fontSize } = this.state;
-    const isGrayedOut = disabled || readOnly;
-    const computedValue = this.computedValue;
-    const { start, end = max } = computedValue;
-    const unit = 100 / (max - min);
-
-    // 0.43em is the handle size as defined in the CSS of this component
-    const handleSize = fontSize * 0.462;
-    const padding = isGrayedOut ? handleSize : 0;
-
-    const a: number = isTwoHandled ? start - min : 0;
-    const b: number = isTwoHandled ? end - min : start - min;
-
-    const seg1W = fromPercentToPixel(unit * a, width);
-    const Seg1 = drawSegment(seg1W - padding, 0, true);
-    const seg2W =
-      fromPercentToPixel(unit * b, width) -
-      fromPercentToPixel(unit * a, width) -
-      padding * (isTwoHandled ? 2 : 1);
-    const seg2O = seg1W + (isTwoHandled ? padding : 0);
-    const Seg2 = drawSegment(seg2W, seg2O, false);
-    const Seg3 = drawSegment(
-      fromPercentToPixel(100 - unit * b, width) - padding,
-      fromPercentToPixel(unit * b, width) + padding,
-      true
+const InputRange = styled(
+  ({
+    onChange,
+    values: controlledValues,
+    defaultValues,
+    name,
+    min = 0,
+    max = 100,
+    step = 1,
+    readOnly = false,
+    disabled = false,
+    discrete = false,
+    className,
+    ...props
+  }: Props) => {
+    const [values = [min], setValues] = useControlledState(
+      defaultValues,
+      controlledValues,
+      onChange
     );
+    const [resizeListener, sizes] = useResizeAware();
 
-    return [
-      isTwoHandled && <Segment as={Seg1} key="1" />,
-      <Segment as={Seg2} key="2" on />,
-      <Segment as={Seg3} key="3" />,
-    ];
-  };
+    const [start, end = max] = values;
+    const width = sizes.width;
 
-  // start and end refer to the handle's name
-  handleFocusStart = () => this.setState({ activeHandle: handles.START });
-  handleFocusEnd = () => this.setState({ activeHandle: handles.END });
-  handleMouseDownStart = (evt: MouseEvent) =>
-    this.handleMouseDown(evt, handles.START);
-  handleMouseDownEnd = (evt: MouseEvent) =>
-    this.handleMouseDown(evt, handles.END);
+    const getSegments = React.useCallback(
+      (isTwoHandled: boolean) => {
+        const isGrayedOut = disabled || readOnly;
+        const unit = 100 / (max - min);
 
-  componentDidMount() {
-    this.computeSizes();
-    document.addEventListener('mousemove', this.handleMouseMove);
-    document.addEventListener('mouseup', this.handleMouseUp);
-  }
+        const padding = isGrayedOut ? HANDLE_SIZE : 0;
 
-  componentWillUnmount() {
-    document.removeEventListener('mousemove', this.handleMouseMove);
-    document.removeEventListener('mouseup', this.handleMouseUp);
-  }
+        const a: number = isTwoHandled ? start - min : 0;
+        const b: number = isTwoHandled ? end - min : start - min;
 
-  render() {
-    const {
-      computedValue,
-      props: {
-        discrete,
-        name,
-        min,
-        max,
-        readOnly,
-        disabled,
-        onChange, // eslint-disable-line no-unused-vars
-        step,
-        className,
-        ...props
+        const seg1W = fromPercentToPixel(unit * a, width);
+        const Seg1 = drawSegment(seg1W - padding, 0, true);
+        const seg2W =
+          fromPercentToPixel(unit * b, width) -
+          fromPercentToPixel(unit * a, width) -
+          padding * (isTwoHandled ? 2 : 1);
+        const seg2O = seg1W + (isTwoHandled ? padding : 0);
+        const Seg2 = drawSegment(seg2W, seg2O, false);
+        const Seg3 = drawSegment(
+          fromPercentToPixel(100 - unit * b, width) - padding,
+          fromPercentToPixel(unit * b, width) + padding,
+          true
+        );
+
+        return [
+          isTwoHandled && <Segment as={Seg1} key="1" />,
+          <Segment as={Seg2} key="2" on />,
+          <Segment as={Seg3} key="3" />,
+        ];
       },
-      state: { dragging, activeHandle },
-    } = this;
-
-    const isGrayedOut = readOnly || disabled;
-
-    // Is two handled only if it has both `start` and `end` props
-    const isTwoHandled = isItTwoHandled(computedValue);
-    const valueText = isTwoHandled
-      ? `${computedValue[handles.START]} - ${computedValue[handles.END]}`
-      : `${computedValue[handles.START]}`;
-
-    // If there's a single handle, we keep the original name
-    // in case there are two handles, we append `1` and `2` to the original name
-    // to distinguish them
-    let nameStart, nameEnd;
-    if (hasName(name)) {
-      nameStart = isTwoHandled ? `${name}1` : name;
-      nameEnd = `${name}2`;
-    }
-
-    // Ticks shouldn't overlap with handles, we hide them if necessary
-    const hiddenTicks = Object.values(computedValue)
-      .map(
-        (value): ?number =>
-          typeof value === 'number' ? (value - min) / step : undefined
-      )
-      .filter(value => value !== undefined);
+      [disabled, min, max, readOnly, width, start, end]
+    );
 
     return (
-      <Container
-        as={ResizeAware}
-        role="slider"
-        aria-valuemin={min}
-        aria-valuemax={max}
-        aria-valuetext={valueText}
-        aria-readonly={readOnly}
-        aria-disabled={disabled}
-        aria-orientation="horizontal"
-        onResize={this.computeSizes}
-        {...props}
-      >
-        <Track
-          disabled={isGrayedOut}
-          ref={el => el !== null && (this.track = el)}
-          onMouseDown={this.handleTrackMouseDown}
-          data-action="click-track"
-        >
-          {this.getSegments(isTwoHandled)}
-        </Track>
-        <Handle
-          value={computedValue[handles.START]}
-          name={hasName(name) ? nameStart : undefined}
-          disabled={disabled}
-          readOnly={readOnly}
-          dragging={activeHandle === handles.START && dragging}
-          onMouseDown={this.handleMouseDownStart}
-          onKeyDown={this.handleKeyDown}
-          offset={Math.round(
-            ((computedValue[handles.START] - min) / (max - min)) *
-              this.state.width
-          )}
-          onFocus={this.handleFocusStart}
-        />
-        {discrete && (
-          <StepTicks step={step} min={min} max={max} hidden={hiddenTicks} />
-        )}
-        {isTwoHandled && (
-          <Handle
-            value={computedValue[handles.END]}
-            name={hasName(name) ? nameEnd : undefined}
-            disabled={disabled}
-            readOnly={readOnly}
-            dragging={activeHandle === handles.END && dragging}
-            onMouseDown={this.handleMouseDownEnd}
-            onKeyDown={this.handleKeyDown}
-            offset={Math.round(
-              ((computedValue[handles.END] - min) / (max - min)) *
-                this.state.width
+      <Range
+        values={values}
+        onChange={setValues}
+        min={min}
+        max={max}
+        step={step}
+        disabled={disabled || readOnly}
+        renderTrack={({ props, children }) => (
+          <Track {...props} disabled={disabled} className={className}>
+            {children}
+            {getSegments(values.length === 2)}
+            {discrete && (
+              <StepTicks step={step} min={min} max={max} values={values} />
             )}
-            onFocus={this.handleFocusEnd}
-          />
+            {resizeListener}
+          </Track>
         )}
-      </Container>
+        renderThumb={({ index, props, value }) => {
+          const { transform, zIndex, ...styles } = props.style;
+          return (
+            <div
+              style={{ position: 'absolute', zIndex: zIndex + 1, transform }}
+            >
+              <Handle
+                {...props}
+                style={styles}
+                value={value}
+                disabled={disabled}
+                readOnly={readOnly}
+                name={`${name}${index}`}
+              />
+            </div>
+          );
+        }}
+        {...props}
+      />
     );
   }
-}
+)();
 
-const InputRange = styled(Inner)();
-
-// @component
 export default InputRange;

--- a/packages/react-forms/src/InputRange/index.test.js
+++ b/packages/react-forms/src/InputRange/index.test.js
@@ -7,31 +7,49 @@
 // @flow
 import * as React from 'react';
 import { mount } from 'enzyme';
-import { colors } from '@quid/theme';
-import InputRange, {
-  getDecimals,
-  toFixed,
-  valueToObject,
-  computeW3cDefaultValue,
-  areValuesEqual,
-  Rect,
-} from '.';
-import { Track, TRACK_BACKGROUND } from './styles';
+import InputRange from '.';
+import { Track, Rect, TRACK_BACKGROUND, HANDLE_SIZE } from './styles';
 import Handle from './Handle';
 
+jest.mock('react-resize-aware', () => () => [
+  null,
+  { width: 1000, height: 10 },
+]);
+jest.mock('react-range', () => ({
+  __esModule: true,
+  Range: ({ renderTrack, renderThumb, values, ...props }) => (
+    <x-range {...props}>
+      {renderTrack({ props: { style: { zIndex: 0 } } })}
+      {values.map((value, index) =>
+        renderThumb({ props: { style: { zIndex: 0 }, value, index } })
+      )}
+    </x-range>
+  ),
+}));
+
 it('renders an InputRange', () => {
+  expect(mount(<InputRange name="x" />)).toMatchSnapshot();
+});
+
+it('renders a disabled InputRange', () => {
   expect(
-    mount(
-      <InputRange
-        step={5}
-        min={0}
-        max={10}
-        defaultValue={0}
-        name="x"
-        discrete
-      />
-    )
-  ).toMatchSnapshot();
+    mount(<InputRange name="x" disabled />)
+      .find('rect')
+      .at(1)
+      .prop('width')
+  ).toBe(994);
+});
+
+it('renders a discrete InputRange', () => {
+  expect(
+    mount(<InputRange name="x" discrete step={10} />).find('Tick')
+  ).toHaveLength(12);
+});
+
+it('renders a double handle InputRange', () => {
+  expect(
+    mount(<InputRange name="x" defaultValues={[20, 80]} />).find('Handle')
+  ).toHaveLength(2);
 });
 
 it('renders a Track component', () => {
@@ -40,19 +58,7 @@ it('renders a Track component', () => {
 });
 
 it('renders a disabled Handle', () => {
-  expect(
-    mount(<Handle disabled />)
-      .find('input')
-      .prop('disabled')
-  ).toBeTruthy();
-});
-
-it('renders a zero Handle', () => {
-  expect(mount(<Handle zero />)).toHaveStyleRule(
-    'border',
-    `1px solid ${colors.gray4}`,
-    { target: '::before' }
-  );
+  expect(mount(<Handle disabled />).prop('tabIndex')).toBe(undefined);
 });
 
 it('renders a dragging Handle', () => {
@@ -63,52 +69,10 @@ it('renders a dragging Handle', () => {
 
 it('returns the alt background on dark theme', () => {
   expect(
-    TRACK_BACKGROUND({ theme: { current: 'dark', colors: { gray2: 'gray2' } } })
+    TRACK_BACKGROUND({
+      theme: ({ current: 'dark', colors: { gray2: 'gray2' } }: any),
+    })
   ).toMatchInlineSnapshot(`"gray2"`);
-});
-
-it('tests getDecimals', () => {
-  expect(getDecimals(10.123)).toBe(3);
-  expect(getDecimals(10)).toBe(0);
-});
-
-it('tests toFixed', () => {
-  expect(toFixed(10.1234, 2)).toBe('10.12');
-  expect(toFixed(10, 2)).toBe('10.00');
-});
-
-it('tests valueToObject', () => {
-  expect(valueToObject(10)).toMatchInlineSnapshot(`
-Object {
-  "start": 10,
-}
-`);
-  expect(valueToObject({ start: 5 })).toMatchInlineSnapshot(`
-Object {
-  "start": 5,
-}
-`);
-  expect(valueToObject({ start: 5, end: 10 })).toMatchInlineSnapshot(`
-Object {
-  "end": 10,
-  "start": 5,
-}
-`);
-  expect(valueToObject({ end: 10 })).toMatchInlineSnapshot(`
-Object {
-  "end": 10,
-}
-`);
-});
-
-it('tests computeW3cDefaultValue', () => {
-  expect(computeW3cDefaultValue(0, 10)).toBe(5);
-  expect(computeW3cDefaultValue(10, 0)).toBe(10);
-});
-
-it('tests areValuesEqual', () => {
-  expect(areValuesEqual(1, 1)).toBeTruthy();
-  expect(areValuesEqual(1, 2)).toBeFalsy();
 });
 
 it('renders Rect', () => {

--- a/packages/react-forms/src/InputRange/styles.js
+++ b/packages/react-forms/src/InputRange/styles.js
@@ -14,10 +14,11 @@ export const HANDLE_SIZE = BASE_HANDLE_SIZE;
 export const TICK_HEIGHT = 6;
 export const TICK_WIDTH = 2;
 
-export const TRACK_BACKGROUND = (props: Object) =>
+export const TRACK_BACKGROUND = wf((props: Object) =>
   props.theme.current === 'light'
     ? props.theme.colors.gray4
-    : props.theme.colors.gray2;
+    : props.theme.colors.gray2
+);
 
 export const Container = styled.div`
   position: relative;
@@ -64,30 +65,52 @@ export const Tick = styled.div`
   transform: translateX(${TICK_WIDTH / 2}px) translateY(${TICK_HEIGHT / 2}px);
   color: ${wf(props => props.theme.selected)};
   border-radius: ${TICK_WIDTH}px;
-  background-color: ${wf(TRACK_BACKGROUND)};
-  opacity: ${props => (props.hidden ? 0 : 1)};
+  background-color: ${TRACK_BACKGROUND};
+  opacity: ${wf(props => (props.hidden ? 0 : 1))};
 
   &:first-of-type {
     transform: translateY(${TICK_HEIGHT / 2}px);
   }
 `;
 
-export const StepTicks = styled(({ step, max, min, hidden, ...props }) => (
-  <div {...props}>
-    {Array(Math.ceil((max - min) / step) + 2)
-      .fill()
-      .map((_, key) => (
-        <Tick key={key} hidden={hidden.includes(key)} />
-      ))}
-  </div>
-))`
+export const StepTicks = styled(({ step, max, min, values, ...props }) => {
+  const hidden = values
+    .map(value => (value - min) / step)
+    .filter(value => value !== undefined);
+
+  return (
+    <div {...props}>
+      {Array(Math.ceil((max - min) / step) + 2)
+        .fill()
+        .map((_, key) => (
+          <Tick key={key} hidden={hidden.includes(key)} />
+        ))}
+    </div>
+  );
+})`
   pointer-events: none;
-  z-index: 1;
+  z-index: 0;
   display: flex;
   position: absolute;
   left: 0;
-  top: 0;
+  top: -${BASE_HANDLE_SIZE - 1}px;
   right: 0;
   bottom: 0;
   justify-content: space-between;
+`;
+
+export const Rect = styled(props => (
+  <rect
+    {...props}
+    fill="currentColor"
+    height={2}
+    width={Math.max(props.width, 0)}
+    x={Math.max(props.offset, 0)}
+    rx={1}
+    ry={1}
+  />
+))`
+  color: ${wf(props =>
+    props.disabled ? TRACK_BACKGROUND(props) : props.theme.selected
+  )};
 `;

--- a/packages/react-forms/src/InputRange/utils.js
+++ b/packages/react-forms/src/InputRange/utils.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Quid, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// @flow
+import * as React from 'react';
+import { Rect } from './styles';
+
+export const fromPercentToPixel = (percent: number, width: number): number =>
+  (width / 100) * percent;
+
+export const drawSegment = (
+  width: number,
+  offset: number,
+  disabled: boolean
+) => (props: Object) =>
+  wrapWithSvg(
+    <Rect width={width} offset={offset} disabled={disabled} />,
+    props
+  );
+
+export const wrapWithSvg = (
+  content: React$Element<any>,
+  { className, on, ...props }: { className?: string, on: boolean }
+) => (
+  <svg
+    className={className}
+    xmlns="http://www.w3.org/2000/svg"
+    width="100"
+    height="100"
+    {...props}
+  >
+    {content}
+  </svg>
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,6 +915,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.5.5":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.2.tgz#c3d6e41b304ef10dcf13777a33e7694ec4a9a6dd"
+  integrity sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
@@ -1107,7 +1114,17 @@
     "@emotion/utils" "0.11.2"
     "@emotion/weak-memoize" "0.2.3"
 
-"@emotion/core@^10.0.10", "@emotion/core@^10.0.4", "@emotion/core@^10.0.6":
+"@emotion/cache@^10.0.17":
+  version "10.0.19"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.19.tgz#d258d94d9c707dcadaf1558def968b86bb87ad71"
+  integrity sha512-BoiLlk4vEsGBg2dAqGSJu0vJl/PgVtCYLBFJaEO8RmQzPugXewQCXZJNXTDFaRlfCs0W+quesayav4fvaif5WQ==
+  dependencies:
+    "@emotion/sheet" "0.9.3"
+    "@emotion/stylis" "0.8.4"
+    "@emotion/utils" "0.11.2"
+    "@emotion/weak-memoize" "0.2.4"
+
+"@emotion/core@^10.0.10", "@emotion/core@^10.0.6":
   version "10.0.15"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.15.tgz#b8489d85d64b45bd03abdb8a3d9639ba8a0328d0"
   integrity sha512-VHwwl3k/ddMfQOHYgOJryXOs2rGJ5AfKLQGm5AVolNonnr6tkmDI4nzIMNaPpveoXVs7sP0OrF24UunIPxveQw==
@@ -1116,6 +1133,18 @@
     "@emotion/cache" "^10.0.15"
     "@emotion/css" "^10.0.14"
     "@emotion/serialize" "^0.11.9"
+    "@emotion/sheet" "0.9.3"
+    "@emotion/utils" "0.11.2"
+
+"@emotion/core@^10.0.4":
+  version "10.0.17"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.17.tgz#3367376709721f4ee2068cff54ba581d362789d8"
+  integrity sha512-gykyjjr0sxzVuZBVTVK4dUmYsorc2qLhdYgSiOVK+m7WXgcYTKZevGWZ7TLAgTZvMelCTvhNq8xnf8FR1IdTbg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/cache" "^10.0.17"
+    "@emotion/css" "^10.0.14"
+    "@emotion/serialize" "^0.11.10"
     "@emotion/sheet" "0.9.3"
     "@emotion/utils" "0.11.2"
 
@@ -1133,6 +1162,11 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.2.tgz#53211e564604beb9befa7a4400ebf8147473eeef"
   integrity sha512-RMtr1i6E8MXaBWwhXL3yeOU8JXRnz8GNxHvaUfVvwxokvayUY0zoBeWbKw1S9XkufmGEEdQd228pSZXFkAln8Q==
 
+"@emotion/hash@0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.3.tgz#a166882c81c0c6040975dd30df24fae8549bd96f"
+  integrity sha512-14ZVlsB9akwvydAdaEnVnvqu6J2P6ySv39hYyl/aoB6w/V+bXX0tay8cF6paqbgZsN2n5Xh15uF4pE+GvE+itw==
+
 "@emotion/is-prop-valid@0.8.2", "@emotion/is-prop-valid@^0.8.2":
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.2.tgz#b9692080da79041683021fcc32f96b40c54c59dc"
@@ -1144,6 +1178,22 @@
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.2.tgz#7f4c71b7654068dfcccad29553520f984cc66b30"
   integrity sha512-hnHhwQzvPCW1QjBWFyBtsETdllOM92BfrKWbUTmh9aeOlcVOiXvlPsK4104xH8NsaKfg86PTFsWkueQeUfMA/w==
+
+"@emotion/memoize@0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.3.tgz#5b6b1c11d6a6dddf1f2fc996f74cf3b219644d78"
+  integrity sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow==
+
+"@emotion/serialize@^0.11.10":
+  version "0.11.11"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.11.tgz#c92a5e5b358070a7242d10508143306524e842a4"
+  integrity sha512-YG8wdCqoWtuoMxhHZCTA+egL0RSGdHEc+YCsmiSBPBEDNuVeMWtjEWtGrhUterSChxzwnWBXvzSxIFQI/3sHLw==
+  dependencies:
+    "@emotion/hash" "0.7.3"
+    "@emotion/memoize" "0.7.3"
+    "@emotion/unitless" "0.7.4"
+    "@emotion/utils" "0.11.2"
+    csstype "^2.5.7"
 
 "@emotion/serialize@^0.11.8", "@emotion/serialize@^0.11.9":
   version "0.11.9"
@@ -1219,6 +1269,11 @@
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.3.tgz#dfa0c92efe44a1d1a7974fb49ffeb40ef2da5a27"
   integrity sha512-zVgvPwGK7c1aVdUVc9Qv7SqepOGRDrqCw7KZPSZziWGxSlbII3gmvGLPzLX4d0n0BMbamBacUrN22zOMyFFEkQ==
+
+"@emotion/weak-memoize@0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz#622a72bebd1e3f48d921563b4b60a762295a81fc"
+  integrity sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==
 
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
@@ -3295,7 +3350,7 @@ babel-plugin-macros@2.5.1:
     cosmiconfig "^5.2.0"
     resolve "^1.10.0"
 
-babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.4.2:
+babel-plugin-macros@^2.0.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.6.1.tgz#41f7ead616fc36f6a93180e89697f69f51671181"
   integrity sha512-6W2nwiXme6j1n2erPOnmRiWfObUhWH7Qw1LMi9XZy8cj+KtESu3T6asZvtk5bMQQjX8te35o7CFueiSdL/2NmQ==
@@ -3319,7 +3374,7 @@ babel-plugin-syntax-object-rest-spread@^6.8.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
   integrity sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=
 
-babel-plugin-transform-async-to-promises@^0.8.1:
+babel-plugin-transform-async-to-promises@^0.8.3:
   version "0.8.14"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.14.tgz#8c783aecb1139f39c608f8bb0f5bb69c343c878e"
   integrity sha512-BHw2WriDbnLwaaIydAjVeXXKBal0pWlFWxfo0UKL2CTaSorvRocrsTflni/mzIOP8c+EJ8xHqtbre8GbIm4ehQ==
@@ -12919,10 +12974,15 @@ react-popper@^1.3.3:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
-react-resize-aware@^2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/react-resize-aware/-/react-resize-aware-2.7.2.tgz#38a0040daaa28dfa9b88994889fbb1e2aa66df83"
-  integrity sha512-XyweQ3YTiZzNG1T5PNpCXvnpsI7mdy4A2oeySFToh8v02Yf+kOiUyWprvyp6T68fFB848w2F3RKfzH7KDk75JQ==
+react-range@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/react-range/-/react-range-1.4.1.tgz#f211c0fbf9695bf46bcfcef3047bc46c1dbf3f9b"
+  integrity sha512-uzqRgrFZzQI96H7vS7WNE8yyVrZzNq0N1JJMhgFb9BxBGBzy0LHbZjyhLiSZrbJTFkPD0hC99Z5U/2sGEeuy+Q==
+
+react-resize-aware@^3.0.0-beta.3:
+  version "3.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/react-resize-aware/-/react-resize-aware-3.0.0-beta.3.tgz#35aeddebfc4595f01323d0f473884099c4633f1b"
+  integrity sha512-XRnj1qgEAvrjOM7c/wsrVLBJxu0TNOKrhgWG7OasCdYiQSCyqiACxJUScTIknUk0bGV7MaagBjMa0CCYXK4ktQ==
 
 react-router-dom@^5.0.0:
   version "5.0.1"
@@ -13864,6 +13924,11 @@ rollup-plugin-sizes@^0.4.2:
     lodash.foreach "^4.5.0"
     lodash.sumby "^4.6.0"
     module-details-from-path "^1.0.3"
+
+rollup-plugin-strict-alias@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-strict-alias/-/rollup-plugin-strict-alias-1.0.0.tgz#7079ee25785c5f9506e4430b5abff4c581ac8cfc"
+  integrity sha1-cHnuJXhcX5UG5EMLWr/0xYGsjPw=
 
 rollup-plugin-terser@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [x] I updated the documentation and examples accordingly;

## Changes description

Replaced the InputRange implementation with `react-range`, performance is improved, and the controlled behavior is now fixed.

BREAKING CHANGE: the InputRange “value” property has been replaced by a “values” property that takes an array rather than an object.
This is to reflect the react-range API, which actually makes more sense and it's easier to use.


## Affected packages

<!-- List below all the affected packages -->

- @quid/react-forms

