### PR TITLE
fix(dependency-update): updated use-debouce

### DIFF
--- a/packages/react-popover/package.json
+++ b/packages/react-popover/package.json
@@ -37,6 +37,6 @@
     "color": "^3.1.0",
     "popper.js": "^1.15.0",
     "react-popper": "^1.3.3",
-    "use-debounce": "^2.1.0"
+    "use-debounce": "^3.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14795,10 +14795,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-debounce@^2.1.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-2.2.1.tgz#0b50e98486a17084c2ba063467ea4cd06071fa3d"
-  integrity sha512-5+8dPOaSecXG+hsjjqDu57k+sIfRLQ2fyRVTq8Q+tK2XYLT3FmBxVy3B+C8l33mLuFkiVu6uE5JqbuQIruxh/g==
+use-debounce@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-3.0.1.tgz#da9f63f4e212048cd747a64032aff21e60bc4e69"
+  integrity sha512-uCPUD1BtzNjwJBsMFggtvNRfw5vCsarw75TM6Tcj0kCg58YvMnIAuvcPrl6mA91m4BtVvRfPTajZv1OEQpN+hw==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [ ] I have added unit tests to cover my changes; NA
- [ ] I updated the documentation and examples accordingly; NA

## Changes description

<!-- Describe what your PR changes -->

This PR updates the use-debounce dependency.

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-popover

