### PR TITLE
feat: adds dropdown category selection option

### DIFF
--- a/packages/react-dropdown/src/Categories.js
+++ b/packages/react-dropdown/src/Categories.js
@@ -109,13 +109,10 @@ export const isCategoryItemHighlighted = (
   highlightedIndex: ?HighlightedIndex,
   firstIndex: number,
   lastIndex: number
-) => {
-  return (
-    typeof highlightedIndex === 'number' &&
-    highlightedIndex >= firstIndex &&
-    highlightedIndex <= lastIndex
-  );
-};
+) =>
+  typeof highlightedIndex === 'number' &&
+  highlightedIndex >= firstIndex &&
+  highlightedIndex <= lastIndex;
 
 const CategorySelection = styled(
   ({

--- a/packages/react-dropdown/src/Categories.js
+++ b/packages/react-dropdown/src/Categories.js
@@ -31,7 +31,6 @@ type Props = {
   highlightedIndex: ?HighlightedIndex,
   highlight: boolean,
   selectedItems: Array<DropdownSelectedItem>,
-  enableCategorySelection: boolean,
   multiselect: boolean,
 };
 
@@ -159,7 +158,6 @@ export default function DropdownCategories({
   highlightedIndex,
   highlight,
   selectedItems,
-  enableCategorySelection,
   multiselect,
 }: Props) {
   const sortedItems = categories
@@ -197,20 +195,12 @@ export default function DropdownCategories({
       {categoriesedItems.map(category => {
         const categoryId = category.id;
 
-        const isMultipleCategorySelectionEnabled =
-          enableCategorySelection && multiselect;
-
         const isHighlighted =
           isCategoryItemHighlighted(
             highlightedIndex,
             category.firstIndex,
             category.lastIndex
-          ) ||
-          isCategoryHighlighted(
-            isMultipleCategorySelectionEnabled,
-            highlightedIndex,
-            categoryId
-          );
+          ) || isCategoryHighlighted(multiselect, highlightedIndex, categoryId);
 
         const isSelected = isItemInCategorySelected(
           selectedItems,
@@ -229,7 +219,7 @@ export default function DropdownCategories({
                   <CategorySelection
                     categoryId={categoryId}
                     getItemProps={getItemProps}
-                    enabled={isMultipleCategorySelectionEnabled}
+                    enabled={multiselect}
                     items={category.items.filter(
                       ({ disabled = false }) => disabled === false
                     )}
@@ -248,7 +238,6 @@ export default function DropdownCategories({
                   highlightedIndex={highlightedIndex}
                   selectedItems={selectedItems}
                   highlight={highlight}
-                  enableCategorySelection={enableCategorySelection}
                   multiselect={multiselect}
                 />
               </Divider>

--- a/packages/react-dropdown/src/Categories.js
+++ b/packages/react-dropdown/src/Categories.js
@@ -97,7 +97,7 @@ export const createCategoryIndex = (categoryId: string | number): string => {
 type ID = number | string;
 
 export const isCategoryHighlighted = (
-  enabled: boolean = false,
+  enabled: boolean,
   highlightedIndex: ?HighlightedIndex,
   id: ?ID
 ): boolean =>

--- a/packages/react-dropdown/src/Categories.js
+++ b/packages/react-dropdown/src/Categories.js
@@ -17,6 +17,7 @@ import {
   type DropdownCategory,
   type DropdownSelectedItem,
   type GetItemProps,
+  type HighlightedIndex,
 } from './dropdownTypes.js';
 
 import { type DropdownItemWithIndex } from './Items';
@@ -27,7 +28,7 @@ type Props = {
   inputValue: ?string,
   getItemProps: GetItemProps,
   twoColumn?: boolean,
-  highlightedIndex: ?number | ?string,
+  highlightedIndex: ?HighlightedIndex,
   highlight: boolean,
   selectedItems: Array<DropdownSelectedItem>,
   enableCategorySelection: boolean,
@@ -94,15 +95,26 @@ export const createCategoryIndex = (categoryId: string | number): string => {
   return `group_${categoryId}`;
 };
 
-export const isEntityHighlighted = (
+type ID = number | string;
+
+export const isCategoryHighlighted = (
   enabled: boolean = false,
-  highlightedIndex: ?number | ?string,
-  id: ?number | ?string
-): boolean => {
+  highlightedIndex: ?HighlightedIndex,
+  id: ?ID
+): boolean =>
+  enabled === true &&
+  id != null &&
+  highlightedIndex === createCategoryIndex(id);
+
+export const isCategoryItemHighlighted = (
+  highlightedIndex: ?HighlightedIndex,
+  firstIndex: number,
+  lastIndex: number
+) => {
   return (
-    enabled === true &&
-    id != null &&
-    highlightedIndex === createCategoryIndex(id)
+    typeof highlightedIndex === 'number' &&
+    highlightedIndex >= firstIndex &&
+    highlightedIndex <= lastIndex
   );
 };
 
@@ -189,15 +201,16 @@ export default function DropdownCategories({
           enableCategorySelection && multiselect;
 
         const isHighlighted =
-          highlightedIndex != null &&
-          ((typeof highlightedIndex === 'number' &&
-            highlightedIndex >= category.firstIndex &&
-            highlightedIndex <= category.lastIndex) ||
-            isEntityHighlighted(
-              isMultipleCategorySelectionEnabled,
-              highlightedIndex,
-              categoryId
-            ));
+          isCategoryItemHighlighted(
+            highlightedIndex,
+            category.firstIndex,
+            category.lastIndex
+          ) ||
+          isCategoryHighlighted(
+            isMultipleCategorySelectionEnabled,
+            highlightedIndex,
+            categoryId
+          );
 
         const isSelected = isItemInCategorySelected(
           selectedItems,

--- a/packages/react-dropdown/src/Items.js
+++ b/packages/react-dropdown/src/Items.js
@@ -31,7 +31,7 @@ type Props = {
   highlightedIndex: ?HighlightedIndex,
   highlight: boolean,
   selectedItems: Array<DropdownSelectedItem>,
-  multiselect?: boolean,
+  multiselect: boolean,
 };
 
 const Items = styled.ul`

--- a/packages/react-dropdown/src/Items.js
+++ b/packages/react-dropdown/src/Items.js
@@ -31,7 +31,6 @@ type Props = {
   highlightedIndex: ?HighlightedIndex,
   highlight: boolean,
   selectedItems: Array<DropdownSelectedItem>,
-  enableCategorySelection?: boolean,
   multiselect?: boolean,
 };
 
@@ -99,7 +98,6 @@ export default function DropdownItems({
   selectedItems,
   categoryId,
   highlight,
-  enableCategorySelection,
   multiselect,
   ...props
 }: Props) {
@@ -107,16 +105,10 @@ export default function DropdownItems({
     <Items>
       {items.map((item, i) => {
         const itemIndex = item.hasOwnProperty('index') ? item.index : i;
-        const isMultipleCategorySelectionEnabled =
-          enableCategorySelection && multiselect;
 
         const isHighlighted =
           itemIndex === highlightedIndex ||
-          isCategoryHighlighted(
-            isMultipleCategorySelectionEnabled,
-            highlightedIndex,
-            categoryId
-          );
+          isCategoryHighlighted(multiselect, highlightedIndex, categoryId);
 
         const isSelected = includesId(selectedItems, item.id);
         const isDisabled = Boolean(item.disabled);

--- a/packages/react-dropdown/src/Items.js
+++ b/packages/react-dropdown/src/Items.js
@@ -17,8 +17,9 @@ import {
   type DropdownSelectedItem,
   type GetItemProps,
 } from './dropdownTypes.js';
+import { isEntityHighlighted } from './Categories';
 
-type DropdownItemWithIndex = DropdownItem & { index?: number };
+export type DropdownItemWithIndex = DropdownItem & { index?: number };
 
 type Props = {
   categoryId?: number | string,
@@ -26,9 +27,11 @@ type Props = {
   items: Array<$Shape<DropdownItemWithIndex>>,
   getItemProps: GetItemProps,
   inputValue: ?string,
-  highlightedIndex: ?number,
+  highlightedIndex: ?number | ?string,
   highlight: boolean,
   selectedItems: Array<DropdownSelectedItem>,
+  enableCategorySelection?: boolean,
+  multiselect?: boolean,
 };
 
 const Items = styled.ul`
@@ -95,13 +98,25 @@ export default function DropdownItems({
   selectedItems,
   categoryId,
   highlight,
+  enableCategorySelection,
+  multiselect,
   ...props
 }: Props) {
   return (
     <Items>
       {items.map((item, i) => {
         const itemIndex = item.hasOwnProperty('index') ? item.index : i;
-        const isHighlighted = itemIndex === highlightedIndex;
+        const isMultipleCategorySelectionEnabled =
+          enableCategorySelection && multiselect;
+
+        const isHighlighted =
+          itemIndex === highlightedIndex ||
+          isEntityHighlighted(
+            isMultipleCategorySelectionEnabled,
+            highlightedIndex,
+            categoryId
+          );
+
         const isSelected = includesId(selectedItems, item.id);
         const isDisabled = Boolean(item.disabled);
         const { index, ...itemWithoutIndex } = item;
@@ -115,7 +130,7 @@ export default function DropdownItems({
             twoColumn={twoColumn}
             {...getItemProps({
               index: itemIndex,
-              item: itemWithoutIndex,
+              item: [itemWithoutIndex],
               disabled: isDisabled,
             })}
           >

--- a/packages/react-dropdown/src/Items.js
+++ b/packages/react-dropdown/src/Items.js
@@ -16,8 +16,9 @@ import {
   type DropdownItem,
   type DropdownSelectedItem,
   type GetItemProps,
+  type HighlightedIndex,
 } from './dropdownTypes.js';
-import { isEntityHighlighted } from './Categories';
+import { isCategoryHighlighted } from './Categories';
 
 export type DropdownItemWithIndex = DropdownItem & { index?: number };
 
@@ -27,7 +28,7 @@ type Props = {
   items: Array<$Shape<DropdownItemWithIndex>>,
   getItemProps: GetItemProps,
   inputValue: ?string,
-  highlightedIndex: ?number | ?string,
+  highlightedIndex: ?HighlightedIndex,
   highlight: boolean,
   selectedItems: Array<DropdownSelectedItem>,
   enableCategorySelection?: boolean,
@@ -111,7 +112,7 @@ export default function DropdownItems({
 
         const isHighlighted =
           itemIndex === highlightedIndex ||
-          isEntityHighlighted(
+          isCategoryHighlighted(
             isMultipleCategorySelectionEnabled,
             highlightedIndex,
             categoryId

--- a/packages/react-dropdown/src/List.js
+++ b/packages/react-dropdown/src/List.js
@@ -30,7 +30,6 @@ type Props = {
   highlightedIndex: ?HighlightedIndex,
   selectedItems: Array<DropdownSelectedItem>,
   highlight: boolean,
-  enableCategorySelection: boolean,
   multiselect: boolean,
 };
 
@@ -68,7 +67,6 @@ const DropdownList: React.ComponentType<Props> = styled(
         highlightedIndex,
         selectedItems,
         highlight,
-        enableCategorySelection,
         multiselect,
         ...props
       }: Props,
@@ -88,7 +86,6 @@ const DropdownList: React.ComponentType<Props> = styled(
                 highlightedIndex={highlightedIndex}
                 selectedItems={selectedItems}
                 highlight={highlight}
-                enableCategorySelection={enableCategorySelection}
                 multiselect={multiselect}
               />
             ) : (

--- a/packages/react-dropdown/src/List.js
+++ b/packages/react-dropdown/src/List.js
@@ -16,6 +16,7 @@ import {
   type DropdownCategory,
   type DropdownSelectedItem,
   type GetItemProps,
+  type HighlightedIndex,
 } from './dropdownTypes.js';
 
 type Props = {
@@ -26,7 +27,7 @@ type Props = {
   useFilter?: boolean,
   filterFn: (Array<DropdownItem>, ?string) => Array<DropdownItem>,
   twoColumn?: boolean,
-  highlightedIndex: ?number | ?string,
+  highlightedIndex: ?HighlightedIndex,
   selectedItems: Array<DropdownSelectedItem>,
   highlight: boolean,
   enableCategorySelection: boolean,

--- a/packages/react-dropdown/src/List.js
+++ b/packages/react-dropdown/src/List.js
@@ -26,9 +26,11 @@ type Props = {
   useFilter?: boolean,
   filterFn: (Array<DropdownItem>, ?string) => Array<DropdownItem>,
   twoColumn?: boolean,
-  highlightedIndex: ?number,
+  highlightedIndex: ?number | ?string,
   selectedItems: Array<DropdownSelectedItem>,
   highlight: boolean,
+  enableCategorySelection: boolean,
+  multiselect: boolean,
 };
 
 export const List = styled.div`
@@ -65,6 +67,8 @@ const DropdownList: React.ComponentType<Props> = styled(
         highlightedIndex,
         selectedItems,
         highlight,
+        enableCategorySelection,
+        multiselect,
         ...props
       }: Props,
       ref: React.ElementRef<any>
@@ -83,6 +87,8 @@ const DropdownList: React.ComponentType<Props> = styled(
                 highlightedIndex={highlightedIndex}
                 selectedItems={selectedItems}
                 highlight={highlight}
+                enableCategorySelection={enableCategorySelection}
+                multiselect={multiselect}
               />
             ) : (
               <DropdownItems
@@ -92,6 +98,7 @@ const DropdownList: React.ComponentType<Props> = styled(
                 highlightedIndex={highlightedIndex}
                 selectedItems={selectedItems}
                 highlight={highlight}
+                multiselect={multiselect}
               />
             )}
           </List>

--- a/packages/react-dropdown/src/MultiDownshift.js
+++ b/packages/react-dropdown/src/MultiDownshift.js
@@ -85,7 +85,7 @@ class MultiDownshift extends React.Component<Props, State> {
   };
 
   handleSelection = (
-    selectedItem: DropdownSelectedItem | null,
+    selectedItems: Array<DropdownSelectedItem> | null,
     downshift: ControllerStateAndHelpers<DropdownSelectedItem>
   ) => {
     const callOnChange = selectedItems => {
@@ -95,15 +95,16 @@ class MultiDownshift extends React.Component<Props, State> {
       }
     };
 
-    const selectedItems = this.getSelectedItems();
+    const currentSelection = this.getSelectedItems();
+
     let newSelectedItems = [];
-    if (selectedItem != null) {
+    if (selectedItems != null) {
+      const selectedItem = selectedItems[0];
       if (this.props.multiselect) {
-        if (includesId(selectedItems, selectedItem.id)) {
-          newSelectedItems = this.removeItem(selectedItem, selectedItems);
-        } else {
-          newSelectedItems = this.addSelectedItem(selectedItem, selectedItems);
-        }
+        newSelectedItems = this.toggleSelectedItems(
+          currentSelection,
+          selectedItems
+        );
       } else {
         newSelectedItems = this.replaceItem(selectedItem);
       }
@@ -113,8 +114,8 @@ class MultiDownshift extends React.Component<Props, State> {
       //Updating the inputValue is necessary when Dropdown is used as controlled component and useFilter is true
       this.setState(
         ({ inputValue }) => ({
-          inputValue: selectedItems.length
-            ? selectedItems[selectedItems.length - 1].label
+          inputValue: currentSelection.length
+            ? currentSelection[currentSelection.length - 1].label
             : inputValue,
         }),
         () => {
@@ -133,6 +134,22 @@ class MultiDownshift extends React.Component<Props, State> {
     }
   };
 
+  toggleSelectedItems = (
+    currentSelection: Array<DropdownSelectedItem>,
+    selectedItems: Array<DropdownSelectedItem>
+  ): Array<DropdownSelectedItem> => {
+    const currentSelectedIds = currentSelection.map(({ id }) => id);
+    const duplatedItems = selectedItems.reduce((accumulator, { id }) => {
+      if (currentSelectedIds.includes(id)) {
+        accumulator.push(id);
+      }
+      return accumulator;
+    }, []);
+    return [...currentSelection, ...selectedItems].filter(({ id }) => {
+      return duplatedItems.includes(id) === false;
+    });
+  };
+
   isSelectedItemsPresentInProps = () => this.props.selectedItems != null;
 
   getSelectedItems = () => this.props.selectedItems || this.state.selectedItems;
@@ -146,11 +163,6 @@ class MultiDownshift extends React.Component<Props, State> {
     selectedItems: Array<DropdownSelectedItem>
   ): Array<DropdownSelectedItem> =>
     selectedItems.filter(({ id }) => id !== item.id);
-
-  addSelectedItem = (
-    item: DropdownSelectedItem,
-    selectedItems: Array<DropdownSelectedItem>
-  ): Array<DropdownSelectedItem> => [...selectedItems, item];
 
   getStateAndHelpers = (
     downshift: ControllerStateAndHelpers<DropdownSelectedItem>

--- a/packages/react-dropdown/src/MultiDownshift.js
+++ b/packages/react-dropdown/src/MultiDownshift.js
@@ -10,7 +10,6 @@ import Downshift, {
   type StateChangeOptions,
 } from 'downshift';
 import * as React from 'react';
-import { includesId } from './utils';
 import { type DropdownSelectedItem } from './dropdownTypes.js';
 
 export type MultiControllerStateAndHelpers = ControllerStateAndHelpers<DropdownSelectedItem> & {

--- a/packages/react-dropdown/src/MultiDownshift.js
+++ b/packages/react-dropdown/src/MultiDownshift.js
@@ -84,7 +84,7 @@ class MultiDownshift extends React.Component<Props, State> {
   };
 
   handleSelection = (
-    selectedItems: Array<DropdownSelectedItem> | null,
+    selectedItems: ?Array<DropdownSelectedItem>,
     downshift: ControllerStateAndHelpers<DropdownSelectedItem>
   ) => {
     const callOnChange = selectedItems => {
@@ -138,14 +138,14 @@ class MultiDownshift extends React.Component<Props, State> {
     selectedItems: Array<DropdownSelectedItem>
   ): Array<DropdownSelectedItem> => {
     const currentSelectedIds = currentSelection.map(({ id }) => id);
-    const duplatedItems = selectedItems.reduce((accumulator, { id }) => {
+    const duplicatedItems = selectedItems.reduce((accumulator, { id }) => {
       if (currentSelectedIds.includes(id)) {
         accumulator.push(id);
       }
       return accumulator;
     }, []);
     return [...currentSelection, ...selectedItems].filter(({ id }) => {
-      return duplatedItems.includes(id) === false;
+      return duplicatedItems.includes(id) === false;
     });
   };
 
@@ -160,13 +160,14 @@ class MultiDownshift extends React.Component<Props, State> {
   removeItem = (
     item: DropdownSelectedItem,
     selectedItems: Array<DropdownSelectedItem>
-  ): Array<DropdownSelectedItem> =>
-    selectedItems.filter(({ id }) => id !== item.id);
+  ): Array<DropdownSelectedItem> => {
+    console.log('RemoveItem');
+    return selectedItems.filter(({ id }) => id !== item.id);
+  };
 
   getStateAndHelpers = (
     downshift: ControllerStateAndHelpers<DropdownSelectedItem>
   ): MultiControllerStateAndHelpers => ({
-    removeItem: this.removeItem,
     selectedItems: this.getSelectedItems(),
     ...downshift,
   });

--- a/packages/react-dropdown/src/MultiDownshift.js
+++ b/packages/react-dropdown/src/MultiDownshift.js
@@ -157,14 +157,6 @@ class MultiDownshift extends React.Component<Props, State> {
     item,
   ];
 
-  removeItem = (
-    item: DropdownSelectedItem,
-    selectedItems: Array<DropdownSelectedItem>
-  ): Array<DropdownSelectedItem> => {
-    console.log('RemoveItem');
-    return selectedItems.filter(({ id }) => id !== item.id);
-  };
-
   getStateAndHelpers = (
     downshift: ControllerStateAndHelpers<DropdownSelectedItem>
   ): MultiControllerStateAndHelpers => ({

--- a/packages/react-dropdown/src/__snapshots__/index.test.js.snap
+++ b/packages/react-dropdown/src/__snapshots__/index.test.js.snap
@@ -128,7 +128,6 @@ exports[`renders an open dropdown 1`] = `
         />
         <DropdownList
           categories={Array []}
-          enableCategorySelection={false}
           filterFn={[Function]}
           getItemProps={[Function]}
           highlight={false}
@@ -156,7 +155,6 @@ exports[`renders an open dropdown 1`] = `
           <ForwardRef
             categories={Array []}
             className="emotion-13 emotion-10"
-            enableCategorySelection={false}
             filterFn={[Function]}
             getItemProps={[Function]}
             highlight={false}
@@ -430,7 +428,6 @@ exports[`renders an open dropdown with categories 1`] = `
             },
           ]
         }
-        enableCategorySelection={false}
         filterFn={[Function]}
         getItemProps={[Function]}
         highlight={false}
@@ -479,7 +476,6 @@ exports[`renders an open dropdown with categories 1`] = `
             ]
           }
           className="emotion-43 emotion-40"
-          enableCategorySelection={false}
           filterFn={[Function]}
           getItemProps={[Function]}
           highlight={false}
@@ -985,7 +981,6 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
               },
             ]
           }
-          enableCategorySelection={false}
           filterFn={[Function]}
           getItemProps={[Function]}
           highlight={false}
@@ -1034,7 +1029,6 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
               ]
             }
             className="emotion-43 emotion-40"
-            enableCategorySelection={false}
             filterFn={[Function]}
             getItemProps={[Function]}
             highlight={false}
@@ -1678,7 +1672,6 @@ exports[`using useFilter should only return items that match the input value 1`]
         />
         <DropdownList
           categories={Array []}
-          enableCategorySelection={false}
           filterFn={[Function]}
           getItemProps={[Function]}
           highlight={true}
@@ -1763,7 +1756,6 @@ exports[`using useFilter should only return items that match the input value 1`]
           <ForwardRef
             categories={Array []}
             className="emotion-17 emotion-14"
-            enableCategorySelection={false}
             filterFn={[Function]}
             getItemProps={[Function]}
             highlight={true}

--- a/packages/react-dropdown/src/__snapshots__/index.test.js.snap
+++ b/packages/react-dropdown/src/__snapshots__/index.test.js.snap
@@ -128,6 +128,7 @@ exports[`renders an open dropdown 1`] = `
         />
         <DropdownList
           categories={Array []}
+          enableCategorySelection={false}
           filterFn={[Function]}
           getItemProps={[Function]}
           highlight={false}
@@ -147,6 +148,7 @@ exports[`renders an open dropdown 1`] = `
               },
             ]
           }
+          multiselect={false}
           selectedItems={Array []}
           twoColumn={true}
           useFilter={false}
@@ -154,6 +156,7 @@ exports[`renders an open dropdown 1`] = `
           <ForwardRef
             categories={Array []}
             className="emotion-13 emotion-10"
+            enableCategorySelection={false}
             filterFn={[Function]}
             getItemProps={[Function]}
             highlight={false}
@@ -173,6 +176,7 @@ exports[`renders an open dropdown 1`] = `
                 },
               ]
             }
+            multiselect={false}
             selectedItems={Array []}
             twoColumn={true}
             useFilter={false}
@@ -426,6 +430,7 @@ exports[`renders an open dropdown with categories 1`] = `
             },
           ]
         }
+        enableCategorySelection={false}
         filterFn={[Function]}
         getItemProps={[Function]}
         highlight={false}
@@ -455,6 +460,7 @@ exports[`renders an open dropdown with categories 1`] = `
             },
           ]
         }
+        multiselect={false}
         selectedItems={Array []}
         twoColumn={false}
         useFilter={false}
@@ -473,6 +479,7 @@ exports[`renders an open dropdown with categories 1`] = `
             ]
           }
           className="emotion-43 emotion-40"
+          enableCategorySelection={false}
           filterFn={[Function]}
           getItemProps={[Function]}
           highlight={false}
@@ -502,6 +509,7 @@ exports[`renders an open dropdown with categories 1`] = `
               },
             ]
           }
+          multiselect={false}
           selectedItems={Array []}
           twoColumn={false}
           useFilter={false}
@@ -533,13 +541,35 @@ exports[`renders an open dropdown with categories 1`] = `
                           <section
                             className="emotion-2 emotion-3"
                           >
-                            <GroupTitle>
-                              <h3
-                                className="emotion-0 emotion-1"
-                              >
-                                Category A
-                              </h3>
-                            </GroupTitle>
+                            <CategorySelection
+                              categoryId="a"
+                              enabled={false}
+                              getItemProps={[Function]}
+                              items={
+                                Array [
+                                  Object {
+                                    "categoryId": "a",
+                                    "id": 10,
+                                    "index": 0,
+                                    "label": "One",
+                                  },
+                                  Object {
+                                    "categoryId": "a",
+                                    "id": 22,
+                                    "index": 1,
+                                    "label": "Two",
+                                  },
+                                ]
+                              }
+                            >
+                              <GroupTitle>
+                                <h3
+                                  className="emotion-0 emotion-1"
+                                >
+                                  Category A
+                                </h3>
+                              </GroupTitle>
+                            </CategorySelection>
                           </section>
                         </Divider>
                         <Divider
@@ -656,13 +686,35 @@ exports[`renders an open dropdown with categories 1`] = `
                           <section
                             className="emotion-2 emotion-3"
                           >
-                            <GroupTitle>
-                              <h3
-                                className="emotion-0 emotion-1"
-                              >
-                                Category B
-                              </h3>
-                            </GroupTitle>
+                            <CategorySelection
+                              categoryId="b"
+                              enabled={false}
+                              getItemProps={[Function]}
+                              items={
+                                Array [
+                                  Object {
+                                    "categoryId": "b",
+                                    "id": 33,
+                                    "index": 2,
+                                    "label": "Three",
+                                  },
+                                  Object {
+                                    "categoryId": "b",
+                                    "id": 44,
+                                    "index": 3,
+                                    "label": "Four",
+                                  },
+                                ]
+                              }
+                            >
+                              <GroupTitle>
+                                <h3
+                                  className="emotion-0 emotion-1"
+                                >
+                                  Category B
+                                </h3>
+                              </GroupTitle>
+                            </CategorySelection>
                           </section>
                         </Divider>
                         <Divider
@@ -933,6 +985,7 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
               },
             ]
           }
+          enableCategorySelection={false}
           filterFn={[Function]}
           getItemProps={[Function]}
           highlight={false}
@@ -962,6 +1015,7 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
               },
             ]
           }
+          multiselect={false}
           selectedItems={Array []}
           twoColumn={true}
           useFilter={false}
@@ -980,6 +1034,7 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
               ]
             }
             className="emotion-43 emotion-40"
+            enableCategorySelection={false}
             filterFn={[Function]}
             getItemProps={[Function]}
             highlight={false}
@@ -1009,6 +1064,7 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                 },
               ]
             }
+            multiselect={false}
             selectedItems={Array []}
             twoColumn={true}
             useFilter={false}
@@ -1040,13 +1096,35 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                             <section
                               className="emotion-2 emotion-3"
                             >
-                              <GroupTitle>
-                                <h3
-                                  className="emotion-0 emotion-1"
-                                >
-                                  Category A
-                                </h3>
-                              </GroupTitle>
+                              <CategorySelection
+                                categoryId="a"
+                                enabled={false}
+                                getItemProps={[Function]}
+                                items={
+                                  Array [
+                                    Object {
+                                      "categoryId": "a",
+                                      "id": 10,
+                                      "index": 0,
+                                      "label": "One",
+                                    },
+                                    Object {
+                                      "categoryId": "a",
+                                      "id": 22,
+                                      "index": 1,
+                                      "label": "Two",
+                                    },
+                                  ]
+                                }
+                              >
+                                <GroupTitle>
+                                  <h3
+                                    className="emotion-0 emotion-1"
+                                  >
+                                    Category A
+                                  </h3>
+                                </GroupTitle>
+                              </CategorySelection>
                             </section>
                           </Divider>
                           <Divider
@@ -1163,13 +1241,35 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
                             <section
                               className="emotion-2 emotion-3"
                             >
-                              <GroupTitle>
-                                <h3
-                                  className="emotion-0 emotion-1"
-                                >
-                                  Category B
-                                </h3>
-                              </GroupTitle>
+                              <CategorySelection
+                                categoryId="b"
+                                enabled={false}
+                                getItemProps={[Function]}
+                                items={
+                                  Array [
+                                    Object {
+                                      "categoryId": "b",
+                                      "id": 33,
+                                      "index": 2,
+                                      "label": "Three",
+                                    },
+                                    Object {
+                                      "categoryId": "b",
+                                      "id": 44,
+                                      "index": 3,
+                                      "label": "Four",
+                                    },
+                                  ]
+                                }
+                              >
+                                <GroupTitle>
+                                  <h3
+                                    className="emotion-0 emotion-1"
+                                  >
+                                    Category B
+                                  </h3>
+                                </GroupTitle>
+                              </CategorySelection>
                             </section>
                           </Divider>
                           <Divider
@@ -1578,6 +1678,7 @@ exports[`using useFilter should only return items that match the input value 1`]
         />
         <DropdownList
           categories={Array []}
+          enableCategorySelection={false}
           filterFn={[Function]}
           getItemProps={[Function]}
           highlight={true}
@@ -1654,6 +1755,7 @@ exports[`using useFilter should only return items that match the input value 1`]
               },
             ]
           }
+          multiselect={false}
           selectedItems={Array []}
           twoColumn={true}
           useFilter={true}
@@ -1661,6 +1763,7 @@ exports[`using useFilter should only return items that match the input value 1`]
           <ForwardRef
             categories={Array []}
             className="emotion-17 emotion-14"
+            enableCategorySelection={false}
             filterFn={[Function]}
             getItemProps={[Function]}
             highlight={true}
@@ -1737,6 +1840,7 @@ exports[`using useFilter should only return items that match the input value 1`]
                 },
               ]
             }
+            multiselect={false}
             selectedItems={Array []}
             twoColumn={true}
             useFilter={true}

--- a/packages/react-dropdown/src/dropdownTypes.js
+++ b/packages/react-dropdown/src/dropdownTypes.js
@@ -40,3 +40,5 @@ export type GetItemProps = $PropertyType<
   PropGetters<DropdownItem>,
   'getItemProps'
 >;
+
+export type HighlightedIndex = number | string;

--- a/packages/react-dropdown/src/index.js
+++ b/packages/react-dropdown/src/index.js
@@ -60,6 +60,7 @@ type Props = {
     MultiControllerStateAndHelpers
   ) => void,
   renderDropdown?: ({ dropdown: React.Node }) => React.Node,
+  enableCategorySelection?: boolean,
 };
 
 const DropdownContainer = styled.div`
@@ -88,6 +89,7 @@ const Dropdown = ({
   onSelect,
   highlight = false,
   renderDropdown = defaultRenderDropdown,
+  enableCategorySelection = false,
   ...props
 }: Props) => {
   if (defaultSelectedItems != null && selectedItems != null) {
@@ -174,9 +176,13 @@ const Dropdown = ({
                           getItemProps={getItemProps}
                           useFilter={useFilter}
                           filterFn={filterFn}
-                          highlightedIndex={highlightedIndex}
+                          highlightedIndex={
+                            highlightedIndex != null ? highlightedIndex : null
+                          }
                           selectedItems={selectedItems}
                           highlight={highlight}
+                          enableCategorySelection={enableCategorySelection}
+                          multiselect={multiselect}
                         />
                       ),
                     })}

--- a/packages/react-dropdown/src/index.js
+++ b/packages/react-dropdown/src/index.js
@@ -60,7 +60,6 @@ type Props = {
     MultiControllerStateAndHelpers
   ) => void,
   renderDropdown?: ({ dropdown: React.Node }) => React.Node,
-  enableCategorySelection?: boolean,
 };
 
 const DropdownContainer = styled.div`
@@ -89,7 +88,6 @@ const Dropdown = ({
   onSelect,
   highlight = false,
   renderDropdown = defaultRenderDropdown,
-  enableCategorySelection = false,
   ...props
 }: Props) => {
   if (defaultSelectedItems != null && selectedItems != null) {
@@ -181,7 +179,6 @@ const Dropdown = ({
                           }
                           selectedItems={selectedItems}
                           highlight={highlight}
-                          enableCategorySelection={enableCategorySelection}
                           multiselect={multiselect}
                         />
                       ),

--- a/packages/react-dropdown/src/index.md
+++ b/packages/react-dropdown/src/index.md
@@ -107,6 +107,50 @@ const categories = [
 </Dropdown>;
 ```
 
+#### Dropdown with multi-level item list (two columns) and multiselect.
+
+With `multiselect` enabled you are able to select multiple items from the list.
+Additionnaly you may want to add `enableCategorySelection` so that you select all the items from a category.
+
+```js
+import { Dropdown } from '@quid/react-dropdown';
+import { InputText } from '@quid/react-forms';
+
+const items = [
+  { id: 10, categoryId: 'a', label: 'One' },
+  { id: 22, categoryId: 'a', label: 'Two' },
+  { id: 33, categoryId: 'b', label: 'Three' },
+  { id: 44, categoryId: 'b', label: 'Four' },
+  { id: 55, categoryId: 'b', label: 'Four', disabled: true },
+  { id: 66, categoryId: 'b', label: 'Three', disabled: true },
+  { id: 77, categoryId: 'b', label: 'Four' },
+  { id: 88, categoryId: 'b', label: 'Three' },
+  { id: 99, categoryId: 'b', label: 'Four' },
+  { id: 101, categoryId: 'b', label: 'Three' },
+  { id: 111, categoryId: 'b', label: 'Four' },
+  { id: 121, categoryId: 'b', label: 'Three' },
+  { id: 131, categoryId: 'c', label: 'One' },
+];
+
+const categories = [
+  { id: 'a', label: 'Category A' },
+  { id: 'b', label: 'Category B' },
+  { id: 'c', label: 'Category C' },
+];
+
+<Dropdown
+  items={items}
+  multiselect={true}
+  enableCategorySelection={true}
+  categories={categories}
+  twoColumn={false}
+>
+  {({ getInputProps }) => (
+    <InputText readOnly placeholder="Select an item..." {...getInputProps()} />
+  )}
+</Dropdown>;
+```
+
 #### Dropdown with multi-level item list (two columns).
 
 ```js

--- a/packages/react-dropdown/src/index.md
+++ b/packages/react-dropdown/src/index.md
@@ -109,8 +109,7 @@ const categories = [
 
 #### Dropdown with multi-level item list (two columns) and multiselect.
 
-With `multiselect` enabled you are able to select multiple items from the list.
-Additionnaly you may want to add `enableCategorySelection` so that you select all the items from a category.
+With `multiselect` enabled you are able to select multiple items from the list. By clicking on the category you can select / deselect all the items within the category.
 
 ```js
 import { Dropdown } from '@quid/react-dropdown';
@@ -141,7 +140,6 @@ const categories = [
 <Dropdown
   items={items}
   multiselect={true}
-  enableCategorySelection={true}
   categories={categories}
   twoColumn={false}
 >

--- a/packages/react-dropdown/src/index.test.js
+++ b/packages/react-dropdown/src/index.test.js
@@ -16,7 +16,8 @@ import { Item, HIGHLIGHTED, SELECTED } from './Items';
 import {
   Divider,
   createCategoryIndex,
-  isEntityHighlighted,
+  isCategoryHighlighted,
+  isCategoryItemHighlighted,
 } from './Categories';
 import {
   filterItems,
@@ -790,10 +791,17 @@ it('createCategoryIndex fn should create a string', () => {
   expect(createCategoryIndex('12')).toBe('group_12');
 });
 
-it('isEntityHighlighted fn should return boolean based on params', () => {
-  expect(isEntityHighlighted(false, null, null)).toBe(false);
-  expect(isEntityHighlighted(true, 'group_12', 12)).toBe(true);
-  expect(isEntityHighlighted(true, 'group_12', 13)).toBe(false);
+it('isCategoryHighlighted fn should return boolean based on params', () => {
+  expect(isCategoryHighlighted(false, null, null)).toBe(false);
+  expect(isCategoryHighlighted(true, 'group_12', 12)).toBe(true);
+  expect(isCategoryHighlighted(true, 'group_12', 13)).toBe(false);
+});
+
+it('isCategoryItemHighlighted fn should return boolean based on params', () => {
+  expect(isCategoryItemHighlighted(10, 1, 10)).toBe(true);
+  expect(isCategoryItemHighlighted(null, 1, 10)).toBe(false);
+  expect(isCategoryItemHighlighted(50, 1, 10)).toBe(false);
+  expect(isCategoryItemHighlighted(undefined, 1, 10)).toBe(false);
 });
 
 it('enableCategorySelection should allow group selection', () => {

--- a/packages/react-dropdown/src/index.test.js
+++ b/packages/react-dropdown/src/index.test.js
@@ -13,7 +13,11 @@ import DropdownWrapper from './__mocks__/DropdownWrapper';
 import { Dropdown, DropdownList as DL } from './index';
 import DropdownList, { List } from './List';
 import { Item, HIGHLIGHTED, SELECTED } from './Items';
-import { Divider } from './Categories';
+import {
+  Divider,
+  createCategoryIndex,
+  isEntityHighlighted,
+} from './Categories';
 import {
   filterItems,
   includesId,
@@ -312,7 +316,7 @@ it('using arrow down and return key should select another element', () => {
   wrapper.find(Input).simulate('keyDown', { key: 'Enter', keyCode: 13 });
 
   expect(handleSelect).toHaveBeenCalledWith(
-    { categoryId: 'a', id: 10, label: 'One' },
+    [{ categoryId: 'a', id: 10, label: 'One' }],
     expect.any(Object)
   );
 });
@@ -429,7 +433,7 @@ it('Empty item label should not break anything.', () => {
     .simulate('click');
 
   expect(handleSelect).toHaveBeenCalledWith(
-    { id: 10, label: '' },
+    [{ id: 10, label: '' }],
     expect.any(Object)
   );
 });
@@ -780,4 +784,57 @@ it('DropdownList could be styled', () => {
     </StyledDropdown>
   );
   expect(wrapper).toHaveStyleRule('width', '100px', { target: DL });
+});
+
+it('createCategoryIndex fn should create a string', () => {
+  expect(createCategoryIndex('12')).toBe('group_12');
+});
+
+it('isEntityHighlighted fn should return boolean based on params', () => {
+  expect(isEntityHighlighted(false, null, null)).toBe(false);
+  expect(isEntityHighlighted(true, 'group_12', 12)).toBe(true);
+  expect(isEntityHighlighted(true, 'group_12', 13)).toBe(false);
+});
+
+it('enableCategorySelection should allow group selection', () => {
+  const handleSelect = jest.fn();
+  const handleChange = jest.fn();
+  const wrapper = mount(
+    <Dropdown
+      items={items.slice(0, 4)}
+      categories={categories.slice(0, 2)}
+      defaultIsOpen={true}
+      twoColumn={true}
+      enableCategorySelection={true}
+      multiselect={true}
+      onSelect={handleSelect}
+      onChange={handleChange}
+    >
+      {({ getInputProps }) => <input {...getInputProps()} />}
+    </Dropdown>
+  );
+
+  wrapper
+    .find('CategorySelection')
+    .filterWhere(e => {
+      return e.props().categoryId === 'b';
+    })
+    .find('div')
+    .simulate('click');
+
+  expect(handleSelect).toHaveBeenCalledWith(
+    [
+      { categoryId: 'b', id: 33, index: 0, label: 'Three' },
+      { categoryId: 'b', id: 44, index: 1, label: 'Four' },
+    ],
+    expect.any(Object)
+  );
+
+  expect(handleChange).toHaveBeenCalledWith(
+    [
+      { categoryId: 'b', id: 33, index: 0, label: 'Three' },
+      { categoryId: 'b', id: 44, index: 1, label: 'Four' },
+    ],
+    expect.any(Object)
+  );
 });

--- a/packages/react-dropdown/src/index.test.js
+++ b/packages/react-dropdown/src/index.test.js
@@ -804,7 +804,7 @@ it('isCategoryItemHighlighted fn should return boolean based on params', () => {
   expect(isCategoryItemHighlighted(undefined, 1, 10)).toBe(false);
 });
 
-it('enableCategorySelection should allow group selection', () => {
+it('multiselect should allow group selection', () => {
   const handleSelect = jest.fn();
   const handleChange = jest.fn();
   const wrapper = mount(
@@ -813,7 +813,6 @@ it('enableCategorySelection should allow group selection', () => {
       categories={categories.slice(0, 2)}
       defaultIsOpen={true}
       twoColumn={true}
-      enableCategorySelection={true}
       multiselect={true}
       onSelect={handleSelect}
       onChange={handleChange}


### PR DESCRIPTION
## PR checklist

- [X] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [X] I have added unit tests to cover my changes;
- [X] I updated the documentation and examples accordingly;

## Changes description

BREAKING CHANGE: onSelect callback's first param is now array instead of object
Now `multiselect` `true` enables user to select every option by clicking on the category.

![enableDropdownCateg](https://user-images.githubusercontent.com/4391461/66944300-32fb7880-f04d-11e9-88b2-72b684ebe3c9.gif)


## Affected packages

<!-- List below all the affected packages -->

- @quid/react-dropdown

