### PR TITLE
fix: fixes dropdown multiple selection wrong behaviour for input value

### DIFF
--- a/packages/react-dropdown/src/MultiDownshift.js
+++ b/packages/react-dropdown/src/MultiDownshift.js
@@ -46,17 +46,21 @@ class MultiDownshift extends React.Component<Props, State> {
   };
 
   getDefaultInputValue(): string {
-    if (
-      this.props.selectedItems &&
-      this.props.selectedItems.length &&
-      this.props.selectedItems[0].label
-    ) {
-      return this.props.selectedItems[0].label;
+    const { multiselect, selectedItems, defaultSelectedItems } = this.props;
+    if (multiselect) {
+      return '';
     } else if (
-      this.props.defaultSelectedItems.length > 0 &&
-      this.props.defaultSelectedItems[0].label
+      selectedItems &&
+      selectedItems.length &&
+      selectedItems[0].label
     ) {
-      return this.props.defaultSelectedItems[0].label;
+      return selectedItems[0].label;
+    } else if (
+      defaultSelectedItems &&
+      defaultSelectedItems.length > 0 &&
+      defaultSelectedItems[0].label
+    ) {
+      return defaultSelectedItems[0].label;
     } else {
       return '';
     }
@@ -110,17 +114,7 @@ class MultiDownshift extends React.Component<Props, State> {
     }
 
     if (this.isSelectedItemsPresentInProps()) {
-      //Updating the inputValue is necessary when Dropdown is used as controlled component and useFilter is true
-      this.setState(
-        ({ inputValue }) => ({
-          inputValue: currentSelection.length
-            ? currentSelection[currentSelection.length - 1].label
-            : inputValue,
-        }),
-        () => {
-          callOnChange(newSelectedItems);
-        }
-      );
+      callOnChange(newSelectedItems);
     } else {
       this.setState(
         {
@@ -171,7 +165,7 @@ class MultiDownshift extends React.Component<Props, State> {
   };
 
   render() {
-    const { multiselect, children, ...props } = this.props;
+    const { multiselect, useFilter, children, ...props } = this.props;
     const selectedItems = this.getSelectedItems();
     return (
       <Downshift
@@ -182,6 +176,10 @@ class MultiDownshift extends React.Component<Props, State> {
         onInputValueChange={this.handleInputValueChange}
         stateReducer={this.stateReducer}
         onChange={this.handleSelection}
+        itemToString={item => {
+          if (useFilter && multiselect) return this.state.inputValue;
+          return item && item.label ? item.label : '';
+        }}
         inputValue={this.state.inputValue}
       >
         {downshift => children(this.getStateAndHelpers(downshift))}

--- a/packages/react-dropdown/src/MultiDownshift.js
+++ b/packages/react-dropdown/src/MultiDownshift.js
@@ -177,7 +177,7 @@ class MultiDownshift extends React.Component<Props, State> {
         stateReducer={this.stateReducer}
         onChange={this.handleSelection}
         itemToString={item => {
-          if (useFilter && multiselect) return this.state.inputValue;
+          if (multiselect) return this.state.inputValue;
           return item && item.label ? item.label : '';
         }}
         inputValue={this.state.inputValue}

--- a/packages/react-dropdown/src/__snapshots__/index.test.js.snap
+++ b/packages/react-dropdown/src/__snapshots__/index.test.js.snap
@@ -1527,7 +1527,7 @@ exports[`using arrow down should hover on element 1`] = `
         disabled={false}
         highlight={false}
         value="One"
-        valueToHighlight="Two"
+        valueToHighlight=""
       >
         <span
           className="emotion-0 emotion-1"
@@ -1565,7 +1565,7 @@ exports[`using arrow down should hover on element 1`] = `
         disabled={false}
         highlight={false}
         value="Two"
-        valueToHighlight="Two"
+        valueToHighlight=""
       >
         <span
           className="emotion-0 emotion-1"

--- a/packages/react-dropdown/src/index.js
+++ b/packages/react-dropdown/src/index.js
@@ -105,7 +105,6 @@ const Dropdown = ({
     <Manager>
       <MultiDownshift
         multiselect={multiselect}
-        itemToString={item => (item && item.label ? item.label : '')}
         defaultSelectedItems={defaultSelectedItems || []}
         selectedItems={selectedItems}
         defaultIsOpen={defaultIsOpen}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5806,7 +5806,7 @@ eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@^6.1.0:
+eslint@6.4.0, eslint@^6.1.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.4.0.tgz#5aa9227c3fbe921982b2eda94ba0d7fae858611a"
   integrity sha512-WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==


### PR DESCRIPTION
## PR checklist

- [X] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [ ] I have added unit tests to cover my changes;
- [ ] I updated the documentation and examples accordingly;

## Changes description

## Affected packages

Applying value in the dropdown was clearly a bad decision when multiselect is enabled, because it doesn't make sense. In case useFilter is applied it just messes up the list. I am sure in most cases there is a helper component that displays the values anyways.

Behaviour before:
![DropdownProblematic](https://user-images.githubusercontent.com/4391461/67208743-5a1fc480-f416-11e9-8f9c-21a9332381dc.gif)

& after:
![DropdownProblematicSolution](https://user-images.githubusercontent.com/4391461/67208793-73c10c00-f416-11e9-821b-063927433023.gif)



<!-- List below all the affected packages -->

- @quid/react-dropdown

