### PR TITLE
fix: assign to checkbox only properties provided as props

### DIFF
--- a/packages/react-forms/src/InputCheckbox/index.test.js
+++ b/packages/react-forms/src/InputCheckbox/index.test.js
@@ -16,6 +16,16 @@ it('renders an InputCheckbox', () => {
   expect(wrapper).toMatchSnapshot();
 });
 
+it('renders a checked InputCheckbox', () => {
+  const wrapper = mount(<InputCheckbox defaultChecked />);
+  expect(wrapper.find('input').getDOMNode().attributes).toHaveProperty(
+    'checked'
+  );
+  expect(wrapper.find('input').getDOMNode().attributes).not.toHaveProperty(
+    'value'
+  );
+});
+
 it('renders a disabled InputCheckbox', () => {
   const wrapper = mount(<InputCheckbox disabled />);
   expect(wrapper).toMatchSnapshot();

--- a/packages/react-forms/src/utils/inputPropsFilters.js
+++ b/packages/react-forms/src/utils/inputPropsFilters.js
@@ -40,6 +40,8 @@ export const omit = (obj: Object) => (keys: Array<string>) =>
 
 export const include = (obj: Object) => (keys: Array<string>) =>
   keys.reduce((acc, current) => {
-    acc[current] = obj[current];
+    if (obj.hasOwnProperty(current)) {
+      acc[current] = obj[current];
+    }
     return acc;
   }, {});

--- a/packages/react-forms/src/utils/inputPropsFilters.test.js
+++ b/packages/react-forms/src/utils/inputPropsFilters.test.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Quid, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// @flow
+import { INPUT_ATTRIBUTES, omit, include } from './inputPropsFilters';
+
+describe('include', () => {
+  it('adds to the output only keys present in the provided props object', () => {
+    expect(include({ checked: true })(INPUT_ATTRIBUTES)).not.toHaveProperty(
+      'value'
+    );
+    expect(include({ checked: true })(INPUT_ATTRIBUTES)).toMatchInlineSnapshot(`
+          Object {
+            "checked": true,
+          }
+      `);
+  });
+});
+
+describe('omit', () => {
+  it('adds to the output only keys present in the provided props object', () => {
+    expect(omit({ foo: true })(INPUT_ATTRIBUTES)).not.toHaveProperty('value');
+    expect(omit({ foo: true })(INPUT_ATTRIBUTES)).toMatchInlineSnapshot(`
+      Object {
+        "foo": true,
+      }
+    `);
+  });
+});


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [ ] I updated the documentation and examples accordingly; N/A

## Changes description

<!-- Describe what your PR changes -->

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-forms

