### PR TITLE
fix: show InputNumber arrows only when in use

### DIFF
--- a/packages/react-forms/src/InputNumber/index.js
+++ b/packages/react-forms/src/InputNumber/index.js
@@ -36,6 +36,7 @@ const Caret = styled.button`
   all: unset;
   display: flex;
   align-items: center;
+  overflow: hidden;
   &:focus-visible {
     box-shadow: 0 0 0 0.5px ${wf(props => props.theme.background)},
       0 0 2px 2px ${wf(props => props.theme.selected)};
@@ -100,6 +101,18 @@ const InputNumber = styled(
   }
 )`
   text-align: right;
+
+  ${Addon} {
+    opacity: 0;
+  }
+
+  &:focus,
+  &:focus-within,
+  &:hover {
+    ${Addon} {
+      opacity: 1;
+    }
+  }
 `;
 
 // @component


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [ ] I have added unit tests to cover my changes; N/A
- [ ] I updated the documentation and examples accordingly; N/A

## Changes description

This PR makes the arrows (up/down) of the InputNumber components visible only when the component is focused or hovered.

Also, I fixed a small issue that made the clickable area of one arrow overlap the other.

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-forms

