### PR TITLE
feat: expose INPUT_ATTRIBUTES list

### DIFF
--- a/packages/react-forms/src/InputCheckbox/index.js
+++ b/packages/react-forms/src/InputCheckbox/index.js
@@ -166,11 +166,8 @@ type Props = {};
 const InputCheckbox: React.StatelessFunctionalComponent<Props> = styled(
   props => (
     <label>
-      <Input
-        {...include(props)([...INPUT_ATTRIBUTES, 'disabled'])}
-        type="checkbox"
-      />
-      <Checkbox {...omit(props)(INPUT_ATTRIBUTES)} />
+      <Input {...include(props)(INPUT_ATTRIBUTES)} type="checkbox" />
+      <Checkbox {...omit(props)(INPUT_ATTRIBUTES)} disabled={props.disabled} />
     </label>
   )
 )``;

--- a/packages/react-forms/src/InputRadio/index.js
+++ b/packages/react-forms/src/InputRadio/index.js
@@ -79,11 +79,8 @@ const Circle = styled.div`
 
 const InputRadio = styled(props => (
   <label>
-    <Input
-      {...include(props)([...INPUT_ATTRIBUTES, 'disabled'])}
-      type="radio"
-    />
-    <Circle {...omit(props)(INPUT_ATTRIBUTES)} />
+    <Input {...include(props)(INPUT_ATTRIBUTES)} type="radio" />
+    <Circle {...omit(props)(INPUT_ATTRIBUTES)} disabled={props.disabled} />
   </label>
 ))``;
 

--- a/packages/react-forms/src/InputText/index.js
+++ b/packages/react-forms/src/InputText/index.js
@@ -26,6 +26,7 @@ type Props = {
   onChange?: (SyntheticInputEvent<any>) => void,
   validationErrorMessage?: string,
   focus?: boolean,
+  disabled?: boolean,
 };
 
 // istanbul ignore next
@@ -132,12 +133,13 @@ const InputText: React.StatelessFunctionalComponent<Props> = styled(
               {({ css }) => (
                 <Container
                   {...omit(props)(INPUT_ATTRIBUTES)}
+                  disabled={props.disabled}
                   isInvalid={isInvalid}
                 >
                   <Input
                     ref={mergeRefs(input, ref)}
                     as={as}
-                    {...include(props)([...INPUT_ATTRIBUTES, 'disabled'])}
+                    {...include(props)(INPUT_ATTRIBUTES)}
                     {...getInputProps({ onChange })}
                   />
                   {renderAddon &&

--- a/packages/react-forms/src/InputToggle/index.js
+++ b/packages/react-forms/src/InputToggle/index.js
@@ -132,9 +132,9 @@ class InputToggle extends React.Component<Props, State> {
   render() {
     const isDisabled = this.props.disabled;
     return (
-      <Container {...omit(this.props)(INPUT_ATTRIBUTES)}>
+      <Container {...omit(this.props)(INPUT_ATTRIBUTES)} disabled={isDisabled}>
         <Input
-          {...include(this.props)([...INPUT_ATTRIBUTES, 'disabled'])}
+          {...include(this.props)(INPUT_ATTRIBUTES)}
           id={this.props.id || this.state.id}
           type="checkbox"
         />

--- a/packages/react-forms/src/index.js
+++ b/packages/react-forms/src/index.js
@@ -19,3 +19,4 @@ export { default as InvalidHandler } from '@quid/react-invalid-handler';
 export { default as Label } from './Label';
 export { default as TextArea } from './TextArea';
 export { default as Button } from './Button';
+export { INPUT_ATTRIBUTES } from './utils/inputPropsFilters';

--- a/packages/react-forms/src/index.test.js
+++ b/packages/react-forms/src/index.test.js
@@ -9,21 +9,22 @@ import * as components from '.';
 
 it('exports the expected number of components', () => {
   expect(Object.keys(components)).toMatchInlineSnapshot(`
-Array [
-  "InputCheckbox",
-  "InputColor",
-  "InputDate",
-  "InputFile",
-  "InputGroup",
-  "InputNumber",
-  "InputRadio",
-  "InputRange",
-  "InputText",
-  "InputToggle",
-  "InvalidHandler",
-  "Label",
-  "TextArea",
-  "Button",
-]
-`);
+    Array [
+      "InputCheckbox",
+      "InputColor",
+      "InputDate",
+      "InputFile",
+      "InputGroup",
+      "InputNumber",
+      "InputRadio",
+      "InputRange",
+      "InputText",
+      "InputToggle",
+      "InvalidHandler",
+      "Label",
+      "TextArea",
+      "Button",
+      "INPUT_ATTRIBUTES",
+    ]
+  `);
 });

--- a/packages/react-forms/src/utils/inputPropsFilters.js
+++ b/packages/react-forms/src/utils/inputPropsFilters.js
@@ -28,6 +28,7 @@ export const INPUT_ATTRIBUTES = [
   'title',
   'type',
   'value',
+  'disabled',
 ];
 
 export const omit = (obj: Object) => (keys: Array<string>) =>


### PR DESCRIPTION

<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;
- [ ] I updated the documentation and examples accordingly;

## Changes description

This list is useful when you need to filter out/filter in component properties that need to be passed to children components.

I'm not exposing our `omit` and `include` implementations because I expect consumers to use their own set of utilities (such as lodash) and I don't want to have consumers rely on our internal implementations that may change, or get dropped all together in future.

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-forms

