### PR TITLE
feat: adds support for raw and content object in ExpandableTable

### DIFF
--- a/packages/react-expandable-table/src/index.js
+++ b/packages/react-expandable-table/src/index.js
@@ -24,7 +24,7 @@ import {
   SortIcon,
   TooltipContainer,
 } from './styles';
-import type { Data, ID, SortOrder, Label, Cell } from './types';
+import type { Data, ID, SortOrder } from './types';
 import {
   getSortedData,
   onKeyboardSelect,

--- a/packages/react-expandable-table/src/index.js
+++ b/packages/react-expandable-table/src/index.js
@@ -24,7 +24,7 @@ import {
   SortIcon,
   TooltipContainer,
 } from './styles';
-import type { Data, ID, SortOrder } from './types';
+import type { Data, ID, SortOrder, Label, Cell } from './types';
 import {
   getSortedData,
   onKeyboardSelect,
@@ -124,7 +124,11 @@ export const ItemWrapper = styled(
             key={column.key}
             bold={column.bold}
           >
-            <Ellipsis>{data[column.key]}</Ellipsis>
+            <Ellipsis>
+              {typeof data[column.key] === 'object'
+                ? data[column.key].content
+                : data[column.key]}
+            </Ellipsis>
           </ColumnCell>
         ))}
         <ColumnCell width={`${ARROW_CELL_WIDTH}px`} align="right">

--- a/packages/react-expandable-table/src/index.md
+++ b/packages/react-expandable-table/src/index.md
@@ -86,7 +86,6 @@ initialState = {
     },
     {
       id: '5',
-      name: 'Hulk',
       name: {
         raw: 'Hulk',
         content: <span style={{ color: 'gray' }}>Hulk</span>,

--- a/packages/react-expandable-table/src/index.md
+++ b/packages/react-expandable-table/src/index.md
@@ -87,6 +87,10 @@ initialState = {
     {
       id: '5',
       name: 'Hulk',
+      name: {
+        raw: 'Hulk',
+        content: <span style={{ color: 'gray' }}>Hulk</span>,
+      },
       rank: '5',
       mentions: '35',
       kol_score: '99.10%',

--- a/packages/react-expandable-table/src/index.test.js
+++ b/packages/react-expandable-table/src/index.test.js
@@ -502,3 +502,29 @@ it('checks for tooltip presence', () => {
   infoIcon.find('button').simulate('mouseenter');
   expect(open).toHaveBeenCalled();
 });
+
+it('content should be rendered when provided', () => {
+  const wrapper = mount(
+    <ExpandableTable
+      maxBodyHeight={300}
+      renderRow={props => <ExampleExtendedComponent {...props} />}
+      columns={columns}
+      data={[
+        ...data,
+        {
+          id: '2',
+          name: {
+            raw: 'Hulk',
+            content: <span data-context="hulk">Hulk</span>,
+          },
+          rank: '2',
+          mentions: '38',
+          kol_score: '99.70%',
+          reach: '99.45%',
+        },
+      ]}
+    />
+  );
+
+  expect(wrapper.find('[data-context="hulk"]').exists()).toBe(true);
+});

--- a/packages/react-expandable-table/src/index.test.js
+++ b/packages/react-expandable-table/src/index.test.js
@@ -288,16 +288,35 @@ it('clicking on name in the header should sort data according to names in descen
         ...data,
         {
           id: '5',
-          name: 'Jamie Dimon',
+          name: {
+            raw: 'Iron Manuel',
+            content: <span>Iron Manuel</span>,
+          },
+          rank: '6',
+          mentions: '34',
+          kol_score: '0.00%',
+          reach: '0.00%',
+          score: 300,
+        },
+        {
+          id: '6',
+          name: {
+            raw: 'Jamie Dimon',
+            content: <span>Jamie Dimon</span>,
+          },
           rank: '5',
           mentions: '35',
           kol_score: '99.10%',
           reach: '99.10%',
           score: 250,
         },
+
         {
-          id: '6',
-          name: 'Agustín Carstens',
+          id: '7',
+          name: {
+            raw: 'Agustín Carstens',
+            content: <span>Agustín Carstens</span>,
+          },
           rank: '6',
           mentions: '34',
           kol_score: '0.00%',
@@ -316,6 +335,7 @@ it('clicking on name in the header should sort data according to names in descen
   expect(wrapper.find('Row').map(node => node.text())).toMatchInlineSnapshot(`
 Array [
   "Jamie Dimon53599.10%99.10%angle_down",
+  "Iron Manuel6340.00%0.00%angle_down",
   "Iron Man1993.70%93.60%angle_down",
   "Captain America23899.70%99.45%angle_down",
   "Agustín Carstens6340.00%0.00%angle_down",

--- a/packages/react-expandable-table/src/types.js
+++ b/packages/react-expandable-table/src/types.js
@@ -5,13 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 // @flow
+import * as React from 'react';
 export type ID = string | number;
-
+export type Label = string | number;
 export const ASC: 'asc' = 'asc';
 export const DESC: 'desc' = 'desc';
 export type SortOrder = Array<typeof ASC | typeof DESC | null>;
 
+export type Cell = {
+  raw: Label,
+  content: React.Node,
+};
+
 export type Data = {
   id: ID,
-  [string]: any,
+  [string]: Label | Cell,
 };

--- a/packages/react-expandable-table/src/utils.js
+++ b/packages/react-expandable-table/src/utils.js
@@ -14,8 +14,12 @@ export const getSortedData = (
 ): Array<Data> => {
   if (data.length && sortOrder && sortBy) {
     return [...data].sort((a, b) => {
-      const valueA = a[sortBy];
-      const valueB = b[sortBy];
+      const valueA = String(
+        typeof a[sortBy] === 'object' ? a[sortBy].raw : a[sortBy]
+      );
+      const valueB = String(
+        typeof b[sortBy] === 'object' ? b[sortBy].raw : b[sortBy]
+      );
       const parsedA = parseFloat(valueA);
       const parsedB = parseFloat(valueB);
       if (isNaN(parsedA) === false && isNaN(parsedB) === false) {


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [X] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [X] I have added unit tests to cover my changes;
- [X] I updated the documentation and examples accordingly;

## Changes description
### react-expandable-table:
Adds support for passing React.Node in `data` to the ExpandableTable in the following way:
```
  data: [
    {
      id: '4',
      name: 'Black Widow',
      rank: '4',
      mentions: '17',
      kol_score: '0.00%',
      reach: '0.00%',
      score: 800,
    },
    {
      id: '5',
      name: 'Hulk',
      name: {
        raw: 'Hulk',
        content: <span style={{ color: 'gray' }}>Hulk</span>,
      },
      rank: '5',
      mentions: '35',
      kol_score: '99.10%',
      reach: '99.10%',
      score: 10,
    },
```

`raw` is the raw value. It is needed to no break the sorting functionality. `content` could be a `React.Node` so you could style your component based on your need.


![Screenshot 2019-12-17 at 16 33 51](https://user-images.githubusercontent.com/4391461/71009784-19c58580-20eb-11ea-835f-645208875e64.png)


## Affected packages

<!-- List below all the affected packages -->

- @quid/react-expandable-table

