### PR TITLE
feat: change dropdown selected item background to aqua with 0.2 opacity

### DIFF
--- a/packages/react-dropdown/src/Items.js
+++ b/packages/react-dropdown/src/Items.js
@@ -48,7 +48,12 @@ export const HIGHLIGHTED = (props: { theme: Object }) =>
     ? props.theme.colors.gray1
     : props.theme.colors.gray5;
 
-export const SELECTED = (props: { theme: Object }) => props.theme.colors.gray3;
+export const SELECTED = (props: { theme: Object }) =>
+  props.theme.current === 'light'
+    ? Color(props.theme.colors.aqua)
+        .alpha(0.2)
+        .string()
+    : props.theme.colors.gray3;
 
 export const Item = styled.li`
   display: flex;

--- a/packages/react-dropdown/src/__snapshots__/index.test.js.snap
+++ b/packages/react-dropdown/src/__snapshots__/index.test.js.snap
@@ -1478,7 +1478,7 @@ exports[`using arrow down should hover on element 1`] = `
   flex-direction: row;
   cursor: pointer;
   padding: 5px;
-  background-color: #8F9BA3;
+  background-color: rgba(30,215,209,0.2);
   color: #2E3338;
 }
 


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;

## Changes description

<!-- Describe what your PR changes -->
change dropdown selected item background to aqua with 0.2 opacity
https://github.com/quid/frontend/issues/234

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-dropdown

