### PR TITLE
fix disabled button text color

### DIFF
--- a/packages/react-core/src/Button/__snapshots__/index.test.js.snap
+++ b/packages/react-core/src/Button/__snapshots__/index.test.js.snap
@@ -50,11 +50,16 @@ exports[`renders a Button with small size 1`] = `
   background-color: hsl(210,9.8%,64%);
 }
 
+.emotion-0:disabled {
+  cursor: default;
+}
+
 .emotion-0:disabled,
 .emotion-0:disabled:hover,
 .emotion-0:disabled:focus,
 .emotion-0:disabled:active {
   background-color: rgba(199,204,209,0.4);
+  color: #8F9BA3;
 }
 
 .emotion-0:focus:not(:focus-visible) {
@@ -65,10 +70,6 @@ exports[`renders a Button with small size 1`] = `
 .emotion-0[data-state*='focus'] {
   outline: 0;
   box-shadow: 0 0 0 0.5px #FFFFFF,0 0 2px 2px #C7CCD1;
-}
-
-.emotion-0:disabled {
-  cursor: default;
 }
 
 .emotion-0 .e1t5eso00 {
@@ -155,11 +156,16 @@ exports[`renders a disabled and transparent Button 1`] = `
   background-color: hsl(210,9.8%,64%);
 }
 
+.emotion-0 {
+  cursor: default;
+}
+
 .emotion-0,
 .emotion-0:hover,
 .emotion-0:focus,
 .emotion-0:active {
   background-color: rgba(199,204,209,0.4);
+  color: #8F9BA3;
 }
 
 .emotion-0:focus:not(:focus-visible) {
@@ -170,10 +176,6 @@ exports[`renders a disabled and transparent Button 1`] = `
 .emotion-0[data-state*='focus'] {
   outline: 0;
   box-shadow: 0 0 0 0.5px #FFFFFF,0 0 2px 2px #C7CCD1;
-}
-
-.emotion-0 {
-  cursor: default;
 }
 
 .emotion-0 .e1t5eso00 {
@@ -264,11 +266,16 @@ exports[`renders the expected markup 1`] = `
   background-color: hsl(210,9.8%,64%);
 }
 
+.emotion-0:disabled {
+  cursor: default;
+}
+
 .emotion-0:disabled,
 .emotion-0:disabled:hover,
 .emotion-0:disabled:focus,
 .emotion-0:disabled:active {
   background-color: rgba(199,204,209,0.4);
+  color: #8F9BA3;
 }
 
 .emotion-0:focus:not(:focus-visible) {
@@ -279,10 +286,6 @@ exports[`renders the expected markup 1`] = `
 .emotion-0[data-state*='focus'] {
   outline: 0;
   box-shadow: 0 0 0 0.5px #FFFFFF,0 0 2px 2px #C7CCD1;
-}
-
-.emotion-0:disabled {
-  cursor: default;
 }
 
 .emotion-0 .e1t5eso00 {

--- a/packages/react-core/src/Button/index.js
+++ b/packages/react-core/src/Button/index.js
@@ -220,7 +220,7 @@ const Button: React.StatelessFunctionalComponent<Props> & {
         bottom: -1px;
         margin-left: 0.35em;
         margin-right: 0;
-        &:first-child {
+        &:first-of-type {
           margin-right: 0.35em;
           margin-left: 0;
         }

--- a/packages/react-core/src/Button/index.js
+++ b/packages/react-core/src/Button/index.js
@@ -175,11 +175,13 @@ const Button: React.StatelessFunctionalComponent<Props> & {
         background-color: ${activeMod(color)};
       }
       ${props.disabled ? '&' : '&:disabled'} {
+        cursor: default;
         &,
         &:hover,
         &:focus,
         &:active {
           background-color: ${disabledMod(color)};
+          color: ${props.theme.disabled};
         }
       }
       &:focus:not(:focus-visible) {
@@ -199,17 +201,6 @@ const Button: React.StatelessFunctionalComponent<Props> & {
       background-color: transparent;
       color: ${props.theme.primary};
     `}
-
-
-  ${props => (props.disabled ? '&' : '&:disabled')} {
-    cursor: default;
-    &,
-    &:hover,
-    &:focus,
-    &:active {
-      color: ${props => props.theme.disabled};
-    }
-  }
 
   ${Icon} {
     display: block;


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;
- [x] I have added unit tests to cover my changes;

## Changes description

<!-- Describe what your PR changes -->
`props.theme.disabled` should be placed inside `wf()`

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-core

