### PR TITLE
fix: react-dropdown width

### DIFF
--- a/packages/react-dropdown/src/Categories.js
+++ b/packages/react-dropdown/src/Categories.js
@@ -46,6 +46,7 @@ const Category = styled.main`
   display: flex;
   flex-direction: ${props => (props.twoColumn ? 'row' : 'column')};
   flex-grow: 1;
+  width: 100%;
 `;
 
 export const Divider = styled.section`

--- a/packages/react-dropdown/src/Items.js
+++ b/packages/react-dropdown/src/Items.js
@@ -41,6 +41,7 @@ const Items = styled.ul`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  width: 100%;
 `;
 
 export const HIGHLIGHTED = (props: { theme: Object }) =>

--- a/packages/react-dropdown/src/__snapshots__/index.test.js.snap
+++ b/packages/react-dropdown/src/__snapshots__/index.test.js.snap
@@ -73,6 +73,7 @@ exports[`renders an open dropdown 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+  width: 100%;
 }
 
 .emotion-2 {
@@ -304,6 +305,7 @@ exports[`renders an open dropdown with categories 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+  width: 100%;
 }
 
 .emotion-6 {
@@ -848,6 +850,7 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+  width: 100%;
 }
 
 .emotion-4 {
@@ -1459,6 +1462,7 @@ exports[`using arrow down should hover on element 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+  width: 100%;
 }
 
 .emotion-0 {
@@ -1609,6 +1613,7 @@ exports[`using useFilter should only return items that match the input value 1`]
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+  width: 100%;
 }
 
 .emotion-4 {

--- a/packages/react-dropdown/src/__snapshots__/index.test.js.snap
+++ b/packages/react-dropdown/src/__snapshots__/index.test.js.snap
@@ -354,6 +354,7 @@ exports[`renders an open dropdown with categories 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+  width: 100%;
 }
 
 .emotion-2 {
@@ -903,6 +904,7 @@ exports[`renders an open dropdown with categories and twoColumn 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+  width: 100%;
 }
 
 .emotion-2 {


### PR DESCRIPTION
<!-- thank you for contributing to Refraction! -->

## PR checklist

- [x] I have followed the ["Committing and publishing"](https://github.com/quid/refraction/blob/master/CONTRIBUTING.md) guidelines;

When scroll bar shows up, the item width exceeds the parent width since the width is not specified and passed down to children.
![image](https://user-images.githubusercontent.com/21137152/191708065-d851fae2-4ac9-42a9-9c47-d8c0fd2c3bf9.png)

Set the width to 100% and child components can also set it to 100% so that the width can be adjusted based on the scroll bar is shown/hidden.
![Screen Shot 2022-09-22 at 5 18 04 PM](https://user-images.githubusercontent.com/21137152/191708933-a476857b-f613-4a9d-a0d4-929f0813ef44.png)
![Screen Shot 2022-09-22 at 5 18 13 PM](https://user-images.githubusercontent.com/21137152/191708943-7b2c0159-044f-4533-9627-db5cf0dfeaec.png)


## Changes description

<!-- Describe what your PR changes -->

## Affected packages

<!-- List below all the affected packages -->

- @quid/react-dropdown


- Jira: https://jira.netbase.com/browse/QUID-27293
